### PR TITLE
Upgrade ruby 2

### DIFF
--- a/lib/channel_advisor/service_proxy.rb
+++ b/lib/channel_advisor/service_proxy.rb
@@ -39,9 +39,6 @@ module ChannelAdvisor
             end
             args = args.unshift(options[:account_id])
             client = self.init_client(options[:developer_key], options[:password])
-            
-            verify_mode = configatron.channel_advisor.ssl_config.retrieve('verify_mode', OpenSSL::SSL::VERIFY_PEER)
-            client.streamhandler.client.ssl_config.verify_mode = verify_mode
 
             request_class = service_module.const_get(class_name)
             request = request_class.new(*args)

--- a/spec/lib/channel_advisor/service_proxy_spec.rb
+++ b/spec/lib/channel_advisor/service_proxy_spec.rb
@@ -20,31 +20,6 @@ describe ChannelAdvisor::ServiceProxy do
       ChannelAdvisor::InventoryServiceSOAP::InventoryServiceSoap.should_receive(:new).and_return(@client)
     end
 
-    describe 'SSL config' do
-      before(:each) do
-        double_result = double(Object, :status => 'Success', :resultData => {})
-        response = double(ChannelAdvisor::InventoryServiceSOAP::GetFilteredSkuListResponse,
-          :getFilteredSkuListResult => double_result
-        )
-        @client.should_receive(:getFilteredSkuList).and_return(response)
-      end
-
-      it "sets the default SSL verify mode to VERIFY_PEER" do
-        @ssl_config.should_receive(:verify_mode=).with(OpenSSL::SSL::VERIFY_PEER)
-        inventory = ChannelAdvisor::InventoryService.new
-        inventory.getFilteredSkuList
-      end
-
-      it "sets the SSL verify mode from a configatron parameter" do
-        configatron.temp do
-          configatron.channel_advisor.ssl_config.verify_mode = OpenSSL::SSL::VERIFY_NONE
-          @ssl_config.should_receive(:verify_mode=).with(OpenSSL::SSL::VERIFY_NONE)
-          inventory = ChannelAdvisor::InventoryService.new
-          inventory.getFilteredSkuList
-        end
-      end
-    end
-
     it "handles getFilteredSkuList request" do
       criteria = ChannelAdvisor::InventoryServiceSOAP::InventoryItemCriteria.new
       criteria.skuStartsWith = 'SR123'


### PR DESCRIPTION
@svetlana The default mode is verify peer, which is the secure mode anyways. We never change it from that, so removing this code doesn't really affect anything.