### PR TITLE
Update to V7.

### DIFF
--- a/README
+++ b/README
@@ -33,6 +33,7 @@ How to Generate the API Classes
 
 Change Log
 ----------
+  = 2.0.0 - Updated to CA API v7
   = 0.3.0 - Updated to CA API v6
   = 0.2.0 - Updated to CA API v4
   = 0.1.0 - Updated to CA API v3; Switched to jeweler and bundler

--- a/Rakefile
+++ b/Rakefile
@@ -67,7 +67,7 @@ task :generate do
     `mkdir -p #{service_dir}`
 
     # Generate the files from the wsdl
-    `cd #{service_dir} && wsdl2ruby.rb --wsdl https://api.channeladvisor.com/ChannelAdvisorAPI/v4/#{camel_name}.asmx?WSDL --type client --module_path ChannelAdvisor::#{camel_name}SOAP`
+    `cd #{service_dir} && wsdl2ruby.rb --wsdl https://api.channeladvisor.com/ChannelAdvisorAPI/v7/#{camel_name}.asmx?WSDL --type client --module_path ChannelAdvisor::#{camel_name}SOAP`
 
     # Remove the generated client file
     `rm #{File.join(service_dir, camel_name)}Client.rb`

--- a/channel_advisor.gemspec
+++ b/channel_advisor.gemspec
@@ -5,7 +5,7 @@
 
 Gem::Specification.new do |s|
   s.name = 'channel_advisor'
-  s.version = '1.0.34'
+  s.version = '2.0.0'
 
   s.required_rubygems_version = Gem::Requirement.new('>= 0')
   s.authors = ['Second Rotation, Inc.']

--- a/lib/channel_advisor/admin_service/client.rb
+++ b/lib/channel_advisor/admin_service/client.rb
@@ -6,7 +6,7 @@ module ChannelAdvisor
 module AdminServiceSOAP
 
 class AdminServiceSoap < ::SOAP::RPC::Driver
-  DefaultEndpointUrl = "https://api.channeladvisor.com/ChannelAdvisorAPI/v4/AdminService.asmx"
+  DefaultEndpointUrl = "https://api.channeladvisor.com/ChannelAdvisorAPI/v7/AdminService.asmx"
 
   Methods = [
     [ "http://api.channeladvisor.com/webservices/GetAuthorizationList",

--- a/lib/channel_advisor/admin_service/mapping_registry.rb
+++ b/lib/channel_advisor/admin_service/mapping_registry.rb
@@ -154,7 +154,7 @@ module DefaultMappingRegistry
     :class => ChannelAdvisor::AdminServiceSOAP::GetAuthorizationList,
     :schema_name => XSD::QName.new(NsWebservices, "GetAuthorizationList"),
     :schema_element => [
-      ["localID", "SOAP::SOAPInt"]
+      ["localID", "SOAP::SOAPInteger", [0, 1]]
     ]
   )
 

--- a/lib/channel_advisor/admin_service/types.rb
+++ b/lib/channel_advisor/admin_service/types.rb
@@ -118,7 +118,7 @@ class ResultStatus < ::String
 end
 
 # {http://api.channeladvisor.com/webservices/}GetAuthorizationList
-#   localID - SOAP::SOAPInt
+#   localID - SOAP::SOAPInteger
 class GetAuthorizationList
   attr_accessor :localID
 

--- a/lib/channel_advisor/cart_service/client.rb
+++ b/lib/channel_advisor/cart_service/client.rb
@@ -6,7 +6,7 @@ module ChannelAdvisor
 module CartServiceSOAP
 
 class CartServiceSoap < ::SOAP::RPC::Driver
-  DefaultEndpointUrl = "https://api.channeladvisor.com/ChannelAdvisorAPI/v4/CartService.asmx"
+  DefaultEndpointUrl = "https://api.channeladvisor.com/ChannelAdvisorAPI/v7/CartService.asmx"
 
   Methods = [
     [ "http://api.channeladvisor.com/webservices/GetCart",

--- a/lib/channel_advisor/cart_service/mapping_registry.rb
+++ b/lib/channel_advisor/cart_service/mapping_registry.rb
@@ -89,7 +89,7 @@ module DefaultMappingRegistry
       ["title", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "Title")], [0, 1]],
       ["lineItemID", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "LineItemID")]],
       ["quantity", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "Quantity")]],
-      ["itemSaleSource", ["ChannelAdvisor::CartServiceSOAP::SiteToken", XSD::QName.new(NsOrders, "ItemSaleSource")]],
+      ["itemSaleSource", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ItemSaleSource")], [0, 1]],
       ["unitPrice", ["SOAP::SOAPDecimal", XSD::QName.new(NsOrders, "UnitPrice")]],
       ["currencyCode", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "CurrencyCode")], [0, 1]],
       ["unitWeight", ["ChannelAdvisor::CartServiceSOAP::ItemWeight", XSD::QName.new(NsOrders, "UnitWeight")], [0, 1]]
@@ -113,7 +113,7 @@ module DefaultMappingRegistry
       ["title", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "Title")], [0, 1]],
       ["lineItemID", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "LineItemID")]],
       ["quantity", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "Quantity")]],
-      ["itemSaleSource", ["ChannelAdvisor::CartServiceSOAP::SiteToken", XSD::QName.new(NsOrders, "ItemSaleSource")]],
+      ["itemSaleSource", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ItemSaleSource")], [0, 1]],
       ["unitPrice", ["SOAP::SOAPDecimal", XSD::QName.new(NsOrders, "UnitPrice")]],
       ["allowNegativeQuantity", ["SOAP::SOAPBoolean", XSD::QName.new(NsOrders, "AllowNegativeQuantity")]]
     ]
@@ -122,11 +122,6 @@ module DefaultMappingRegistry
   EncodedRegistry.register(
     :class => ChannelAdvisor::CartServiceSOAP::ResultStatus,
     :schema_type => XSD::QName.new(NsWebservices, "ResultStatus")
-  )
-
-  EncodedRegistry.register(
-    :class => ChannelAdvisor::CartServiceSOAP::SiteToken,
-    :schema_type => XSD::QName.new(NsOrders, "SiteToken")
   )
 
   LiteralRegistry.register(
@@ -209,7 +204,7 @@ module DefaultMappingRegistry
       ["title", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "Title")], [0, 1]],
       ["lineItemID", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "LineItemID")]],
       ["quantity", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "Quantity")]],
-      ["itemSaleSource", ["ChannelAdvisor::CartServiceSOAP::SiteToken", XSD::QName.new(NsOrders, "ItemSaleSource")]],
+      ["itemSaleSource", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ItemSaleSource")], [0, 1]],
       ["unitPrice", ["SOAP::SOAPDecimal", XSD::QName.new(NsOrders, "UnitPrice")]],
       ["currencyCode", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "CurrencyCode")], [0, 1]],
       ["unitWeight", ["ChannelAdvisor::CartServiceSOAP::ItemWeight", XSD::QName.new(NsOrders, "UnitWeight")], [0, 1]]
@@ -233,7 +228,7 @@ module DefaultMappingRegistry
       ["title", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "Title")], [0, 1]],
       ["lineItemID", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "LineItemID")]],
       ["quantity", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "Quantity")]],
-      ["itemSaleSource", ["ChannelAdvisor::CartServiceSOAP::SiteToken", XSD::QName.new(NsOrders, "ItemSaleSource")]],
+      ["itemSaleSource", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ItemSaleSource")], [0, 1]],
       ["unitPrice", ["SOAP::SOAPDecimal", XSD::QName.new(NsOrders, "UnitPrice")]],
       ["allowNegativeQuantity", ["SOAP::SOAPBoolean", XSD::QName.new(NsOrders, "AllowNegativeQuantity")]]
     ]
@@ -245,15 +240,10 @@ module DefaultMappingRegistry
   )
 
   LiteralRegistry.register(
-    :class => ChannelAdvisor::CartServiceSOAP::SiteToken,
-    :schema_type => XSD::QName.new(NsOrders, "SiteToken")
-  )
-
-  LiteralRegistry.register(
     :class => ChannelAdvisor::CartServiceSOAP::GetCart,
     :schema_name => XSD::QName.new(NsWebservices, "GetCart"),
     :schema_element => [
-      ["accountID", "SOAP::SOAPString", [0, 1]],
+      ["accountID", "SOAP::SOAPString"],
       ["cartID", "SOAP::SOAPInt"]
     ]
   )
@@ -279,7 +269,7 @@ module DefaultMappingRegistry
     :class => ChannelAdvisor::CartServiceSOAP::DeleteCart,
     :schema_name => XSD::QName.new(NsWebservices, "DeleteCart"),
     :schema_element => [
-      ["accountID", "SOAP::SOAPString", [0, 1]],
+      ["accountID", "SOAP::SOAPString"],
       ["cartID", "SOAP::SOAPInt"]
     ]
   )
@@ -296,7 +286,7 @@ module DefaultMappingRegistry
     :class => ChannelAdvisor::CartServiceSOAP::CreateCart,
     :schema_name => XSD::QName.new(NsWebservices, "CreateCart"),
     :schema_element => [
-      ["accountID", "SOAP::SOAPString", [0, 1]],
+      ["accountID", "SOAP::SOAPString"],
       ["buyerEmail", "SOAP::SOAPString", [0, 1]],
       ["lineItem", "ChannelAdvisor::CartServiceSOAP::ArrayOfCartItemRequest", [0, 1]]
     ]
@@ -314,10 +304,10 @@ module DefaultMappingRegistry
     :class => ChannelAdvisor::CartServiceSOAP::ModifyCart,
     :schema_name => XSD::QName.new(NsWebservices, "ModifyCart"),
     :schema_element => [
-      ["accountID", "SOAP::SOAPString", [0, 1]],
+      ["accountID", "SOAP::SOAPString"],
       ["cartID", "SOAP::SOAPInt"],
       ["buyerEmail", "SOAP::SOAPString", [0, 1]],
-      ["lineItem", "ChannelAdvisor::CartServiceSOAP::ArrayOfCartItemRequest", [0, 1]]
+      ["lineItemList", "ChannelAdvisor::CartServiceSOAP::ArrayOfCartItemRequest", [0, 1]]
     ]
   )
 

--- a/lib/channel_advisor/cart_service/types.rb
+++ b/lib/channel_advisor/cart_service/types.rb
@@ -126,7 +126,7 @@ end
 #   title - SOAP::SOAPString
 #   lineItemID - SOAP::SOAPInt
 #   quantity - SOAP::SOAPInt
-#   itemSaleSource - ChannelAdvisor::CartServiceSOAP::SiteToken
+#   itemSaleSource - SOAP::SOAPString
 #   unitPrice - SOAP::SOAPDecimal
 class CartItem < InventoryItemBase
   attr_accessor :sKU
@@ -151,7 +151,7 @@ end
 #   title - SOAP::SOAPString
 #   lineItemID - SOAP::SOAPInt
 #   quantity - SOAP::SOAPInt
-#   itemSaleSource - ChannelAdvisor::CartServiceSOAP::SiteToken
+#   itemSaleSource - SOAP::SOAPString
 #   unitPrice - SOAP::SOAPDecimal
 #   currencyCode - SOAP::SOAPString
 #   unitWeight - ChannelAdvisor::CartServiceSOAP::ItemWeight
@@ -182,7 +182,7 @@ end
 #   title - SOAP::SOAPString
 #   lineItemID - SOAP::SOAPInt
 #   quantity - SOAP::SOAPInt
-#   itemSaleSource - ChannelAdvisor::CartServiceSOAP::SiteToken
+#   itemSaleSource - SOAP::SOAPString
 #   unitPrice - SOAP::SOAPDecimal
 #   allowNegativeQuantity - SOAP::SOAPBoolean
 class CartItemRequest < CartItem
@@ -232,41 +232,6 @@ end
 class ResultStatus < ::String
   Failure = new("Failure")
   Success = new("Success")
-end
-
-# {http://api.channeladvisor.com/datacontracts/orders}SiteToken
-class SiteToken < ::String
-  AMAZON_AUCTIONS = new("AMAZON_AUCTIONS")
-  AMAZON_DE = new("AMAZON_DE")
-  AMAZON_FR = new("AMAZON_FR")
-  AMAZON_MARKETPLACE = new("AMAZON_MARKETPLACE")
-  AMAZON_MERCHANTSAT = new("AMAZON_MERCHANTSAT")
-  AMAZON_UK = new("AMAZON_UK")
-  AMAZON_US = new("AMAZON_US")
-  BUY_DOT_COM = new("BUY_DOT_COM")
-  CHANNELADVISOR_STORE = new("CHANNELADVISOR_STORE")
-  DEMANDWARE_STORE = new("DEMANDWARE_STORE")
-  DIRECT_SALE = new("DIRECT_SALE")
-  EBAY_AU = new("EBAY_AU")
-  EBAY_CA = new("EBAY_CA")
-  EBAY_DE = new("EBAY_DE")
-  EBAY_ES = new("EBAY_ES")
-  EBAY_FR = new("EBAY_FR")
-  EBAY_IE = new("EBAY_IE")
-  EBAY_IT = new("EBAY_IT")
-  EBAY_MOTORS = new("EBAY_MOTORS")
-  EBAY_MOTORS_FIXED_PRICE = new("EBAY_MOTORS_FIXED_PRICE")
-  EBAY_STORES = new("EBAY_STORES")
-  EBAY_UK = new("EBAY_UK")
-  EBAY_US = new("EBAY_US")
-  OVERSTOCK = new("OVERSTOCK")
-  OVERSTOCK_SHOPPING = new("OVERSTOCK_SHOPPING")
-  PIXMANIA = new("PIXMANIA")
-  STOREADVISOR_PREMIUM = new("STOREADVISOR_PREMIUM")
-  TRADING_POST = new("TRADING_POST")
-  UNKNOWN = new("UNKNOWN")
-  YAHOO = new("YAHOO")
-  YAHOO_STORES = new("YAHOO_STORES")
 end
 
 # {http://api.channeladvisor.com/webservices/}GetCart
@@ -345,18 +310,18 @@ end
 #   accountID - SOAP::SOAPString
 #   cartID - SOAP::SOAPInt
 #   buyerEmail - SOAP::SOAPString
-#   lineItem - ChannelAdvisor::CartServiceSOAP::ArrayOfCartItemRequest
+#   lineItemList - ChannelAdvisor::CartServiceSOAP::ArrayOfCartItemRequest
 class ModifyCart
   attr_accessor :accountID
   attr_accessor :cartID
   attr_accessor :buyerEmail
-  attr_accessor :lineItem
+  attr_accessor :lineItemList
 
-  def initialize(accountID = nil, cartID = nil, buyerEmail = nil, lineItem = nil)
+  def initialize(accountID = nil, cartID = nil, buyerEmail = nil, lineItemList = nil)
     @accountID = accountID
     @cartID = cartID
     @buyerEmail = buyerEmail
-    @lineItem = lineItem
+    @lineItemList = lineItemList
   end
 end
 

--- a/lib/channel_advisor/inventory_service/client.rb
+++ b/lib/channel_advisor/inventory_service/client.rb
@@ -6,7 +6,7 @@ module ChannelAdvisor
 module InventoryServiceSOAP
 
 class InventoryServiceSoap < ::SOAP::RPC::Driver
-  DefaultEndpointUrl = "https://api.channeladvisor.com/ChannelAdvisorAPI/v4/InventoryService.asmx"
+  DefaultEndpointUrl = "https://api.channeladvisor.com/ChannelAdvisorAPI/v7/InventoryService.asmx"
 
   Methods = [
     [ "http://api.channeladvisor.com/webservices/DoesSkuExist",
@@ -125,6 +125,14 @@ class InventoryServiceSoap < ::SOAP::RPC::Driver
       "getInventoryQuantityList",
       [ [:in, "parameters", ["::SOAP::SOAPElement", "http://api.channeladvisor.com/webservices/", "GetInventoryQuantityList"]],
         [:out, "parameters", ["::SOAP::SOAPElement", "http://api.channeladvisor.com/webservices/", "GetInventoryQuantityListResponse"]] ],
+      { :request_style =>  :document, :request_use =>  :literal,
+        :response_style => :document, :response_use => :literal,
+        :faults => {} }
+    ],
+    [ "http://api.channeladvisor.com/webservices/GetDistributionCenterList",
+      "getDistributionCenterList",
+      [ [:in, "parameters", ["::SOAP::SOAPElement", "http://api.channeladvisor.com/webservices/", "GetDistributionCenterList"]],
+        [:out, "parameters", ["::SOAP::SOAPElement", "http://api.channeladvisor.com/webservices/", "GetDistributionCenterListResponse"]] ],
       { :request_style =>  :document, :request_use =>  :literal,
         :response_style => :document, :response_use => :literal,
         :faults => {} }

--- a/lib/channel_advisor/inventory_service/mapping_registry.rb
+++ b/lib/channel_advisor/inventory_service/mapping_registry.rb
@@ -96,11 +96,11 @@ module DefaultMappingRegistry
       ["subtitle", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Subtitle")], [0, 1]],
       ["shortDescription", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "ShortDescription")], [0, 1]],
       ["description", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Description")], [0, 1]],
-      ["weight", ["SOAP::SOAPDouble", XSD::QName.new(NsWebservices, "Weight")]],
+      ["weight", ["SOAP::SOAPDecimal", XSD::QName.new(NsWebservices, "Weight")]],
       ["supplierCode", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "SupplierCode")], [0, 1]],
       ["warehouseLocation", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "WarehouseLocation")], [0, 1]],
       ["taxProductCode", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "TaxProductCode")], [0, 1]],
-      ["flagStyle", ["ChannelAdvisor::InventoryServiceSOAP::FlagType", XSD::QName.new(NsWebservices, "FlagStyle")]],
+      ["flagStyle", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "FlagStyle")], [0, 1]],
       ["flagDescription", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "FlagDescription")], [0, 1]],
       ["isBlocked", ["SOAP::SOAPBoolean", XSD::QName.new(NsWebservices, "IsBlocked")]],
       ["blockComment", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "BlockComment")], [0, 1]],
@@ -115,20 +115,68 @@ module DefaultMappingRegistry
       ["warranty", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Warranty")], [0, 1]],
       ["productMargin", ["SOAP::SOAPDecimal", XSD::QName.new(NsWebservices, "ProductMargin")]],
       ["supplierPO", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "SupplierPO")], [0, 1]],
-      ["receivedInInventory", ["SOAP::SOAPDateTime", XSD::QName.new(NsWebservices, "ReceivedInInventory")]],
       ["harmonizedCode", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "HarmonizedCode")], [0, 1]],
       ["height", ["SOAP::SOAPDecimal", XSD::QName.new(NsWebservices, "Height")]],
       ["length", ["SOAP::SOAPDecimal", XSD::QName.new(NsWebservices, "Length")]],
       ["width", ["SOAP::SOAPDecimal", XSD::QName.new(NsWebservices, "Width")]],
       ["classification", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Classification")], [0, 1]],
-      ["quantityInfo", ["ChannelAdvisor::InventoryServiceSOAP::QuantityInfoResponse", XSD::QName.new(NsWebservices, "QuantityInfo")], [0, 1]],
+      ["distributionCenterList", ["ChannelAdvisor::InventoryServiceSOAP::ArrayOfDistributionCenterInfoResponse", XSD::QName.new(NsWebservices, "DistributionCenterList")], [0, 1]],
+      ["quantity", ["ChannelAdvisor::InventoryServiceSOAP::QuantityInfoResponse", XSD::QName.new(NsWebservices, "Quantity")], [0, 1]],
       ["priceInfo", ["ChannelAdvisor::InventoryServiceSOAP::PriceInfo", XSD::QName.new(NsWebservices, "PriceInfo")], [0, 1]],
       ["attributeList", ["ChannelAdvisor::InventoryServiceSOAP::ArrayOfAttributeInfo", XSD::QName.new(NsWebservices, "AttributeList")], [0, 1]],
       ["variationInfo", ["ChannelAdvisor::InventoryServiceSOAP::VariationInfo", XSD::QName.new(NsWebservices, "VariationInfo")], [0, 1]],
       ["storeInfo", ["ChannelAdvisor::InventoryServiceSOAP::StoreInfo", XSD::QName.new(NsWebservices, "StoreInfo")], [0, 1]],
       ["imageList", ["ChannelAdvisor::InventoryServiceSOAP::ArrayOfImageInfoResponse", XSD::QName.new(NsWebservices, "ImageList")], [0, 1]],
-      ["shippingInfo", ["ChannelAdvisor::InventoryServiceSOAP::ShippingInfo", XSD::QName.new(NsWebservices, "ShippingInfo")], [0, 1]],
       ["metaDescription", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "MetaDescription")], [0, 1]]
+    ]
+  )
+
+  EncodedRegistry.register(
+    :class => ChannelAdvisor::InventoryServiceSOAP::ArrayOfDistributionCenterInfoResponse,
+    :schema_type => XSD::QName.new(NsWebservices, "ArrayOfDistributionCenterInfoResponse"),
+    :schema_element => [
+      ["distributionCenterInfoResponse", ["ChannelAdvisor::InventoryServiceSOAP::DistributionCenterInfoResponse[]", XSD::QName.new(NsWebservices, "DistributionCenterInfoResponse")], [0, nil]]
+    ]
+  )
+
+  EncodedRegistry.register(
+    :class => ChannelAdvisor::InventoryServiceSOAP::DistributionCenterInfoResponse,
+    :schema_type => XSD::QName.new(NsWebservices, "DistributionCenterInfoResponse"),
+    :schema_element => [
+      ["distributionCenterCode", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "DistributionCenterCode")], [0, 1]],
+      ["availableQuantity", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "AvailableQuantity")]],
+      ["openAllocatedQuantity", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "OpenAllocatedQuantity")]],
+      ["openAllocatedPooledQuantity", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "OpenAllocatedPooledQuantity")]],
+      ["warehouseLocation", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "WarehouseLocation")], [0, 1]],
+      ["receivedInInventory", ["SOAP::SOAPDateTime", XSD::QName.new(NsWebservices, "ReceivedInInventory")]],
+      ["shippingRateList", ["ChannelAdvisor::InventoryServiceSOAP::ArrayOfShippingRateInfo", XSD::QName.new(NsWebservices, "ShippingRateList")], [0, 1]]
+    ]
+  )
+
+  EncodedRegistry.register(
+    :class => ChannelAdvisor::InventoryServiceSOAP::ArrayOfShippingRateInfo,
+    :schema_type => XSD::QName.new(NsWebservices, "ArrayOfShippingRateInfo"),
+    :schema_element => [
+      ["shippingRateInfo", ["ChannelAdvisor::InventoryServiceSOAP::ShippingRateInfo[]", XSD::QName.new(NsWebservices, "ShippingRateInfo")], [0, nil]]
+    ]
+  )
+
+  EncodedRegistry.register(
+    :class => ChannelAdvisor::InventoryServiceSOAP::ShippingRateInfo,
+    :schema_type => XSD::QName.new(NsWebservices, "ShippingRateInfo"),
+    :schema_element => [
+      ["destinationZoneName", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "DestinationZoneName")], [0, 1]],
+      ["carrierCode", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "CarrierCode")], [0, 1]],
+      ["classCode", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "ClassCode")], [0, 1]],
+      ["firstItemRate", ["SOAP::SOAPDecimal", XSD::QName.new(NsWebservices, "FirstItemRate")]],
+      ["additionalItemRate", ["SOAP::SOAPDecimal", XSD::QName.new(NsWebservices, "AdditionalItemRate")]],
+      ["firstItemHandlingRate", ["SOAP::SOAPDecimal", XSD::QName.new(NsWebservices, "FirstItemHandlingRate")]],
+      ["additionalItemHandlingRate", ["SOAP::SOAPDecimal", XSD::QName.new(NsWebservices, "AdditionalItemHandlingRate")]],
+      ["freeShippingIfBuyItNow", ["SOAP::SOAPBoolean", XSD::QName.new(NsWebservices, "FreeShippingIfBuyItNow")]],
+      ["firstItemRateAttribute", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "FirstItemRateAttribute")], [0, 1]],
+      ["firstItemHandlingRateAttribute", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "FirstItemHandlingRateAttribute")], [0, 1]],
+      ["additionalItemRateAttribute", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "AdditionalItemRateAttribute")], [0, 1]],
+      ["additionalItemHandlingRateAttribute", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "AdditionalItemHandlingRateAttribute")], [0, 1]]
     ]
   )
 
@@ -136,14 +184,15 @@ module DefaultMappingRegistry
     :class => ChannelAdvisor::InventoryServiceSOAP::QuantityInfoResponse,
     :schema_type => XSD::QName.new(NsWebservices, "QuantityInfoResponse"),
     :schema_element => [
-      ["total", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "Total")]],
       ["available", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "Available")]],
-      ["open", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "Open")]],
+      ["openAllocated", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "OpenAllocated")]],
+      ["openUnallocated", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "OpenUnallocated")]],
       ["pendingCheckout", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "PendingCheckout")]],
       ["pendingPayment", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "PendingPayment")]],
       ["pendingShipment", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "PendingShipment")]],
-      ["isScheduled", ["SOAP::SOAPBoolean", XSD::QName.new(NsWebservices, "IsScheduled")]],
-      ["openPooled", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "OpenPooled")]],
+      ["total", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "Total")]],
+      ["openAllocatedPooled", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "OpenAllocatedPooled")]],
+      ["openUnallocatedPooled", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "OpenUnallocatedPooled")]],
       ["pendingCheckoutPooled", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "PendingCheckoutPooled")]],
       ["pendingPaymentPooled", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "PendingPaymentPooled")]],
       ["pendingShipmentPooled", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "PendingShipmentPooled")]],
@@ -241,46 +290,10 @@ module DefaultMappingRegistry
   )
 
   EncodedRegistry.register(
-    :class => ChannelAdvisor::InventoryServiceSOAP::ShippingInfo,
-    :schema_type => XSD::QName.new(NsWebservices, "ShippingInfo"),
-    :schema_element => [
-      ["distributionCenterCode", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "DistributionCenterCode")], [0, 1]],
-      ["shippingRateList", ["ChannelAdvisor::InventoryServiceSOAP::ArrayOfShippingRateInfo", XSD::QName.new(NsWebservices, "ShippingRateList")], [0, 1]]
-    ]
-  )
-
-  EncodedRegistry.register(
-    :class => ChannelAdvisor::InventoryServiceSOAP::ArrayOfShippingRateInfo,
-    :schema_type => XSD::QName.new(NsWebservices, "ArrayOfShippingRateInfo"),
-    :schema_element => [
-      ["shippingRateInfo", ["ChannelAdvisor::InventoryServiceSOAP::ShippingRateInfo[]", XSD::QName.new(NsWebservices, "ShippingRateInfo")], [0, nil]]
-    ]
-  )
-
-  EncodedRegistry.register(
-    :class => ChannelAdvisor::InventoryServiceSOAP::ShippingRateInfo,
-    :schema_type => XSD::QName.new(NsWebservices, "ShippingRateInfo"),
-    :schema_element => [
-      ["destinationZoneName", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "DestinationZoneName")], [0, 1]],
-      ["carrierCode", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "CarrierCode")], [0, 1]],
-      ["classCode", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "ClassCode")], [0, 1]],
-      ["firstItemRate", ["SOAP::SOAPDecimal", XSD::QName.new(NsWebservices, "FirstItemRate")]],
-      ["additionalItemRate", ["SOAP::SOAPDecimal", XSD::QName.new(NsWebservices, "AdditionalItemRate")]],
-      ["firstItemHandlingRate", ["SOAP::SOAPDecimal", XSD::QName.new(NsWebservices, "FirstItemHandlingRate")]],
-      ["additionalItemHandlingRate", ["SOAP::SOAPDecimal", XSD::QName.new(NsWebservices, "AdditionalItemHandlingRate")]],
-      ["freeShippingIfBuyItNow", ["SOAP::SOAPBoolean", XSD::QName.new(NsWebservices, "FreeShippingIfBuyItNow")]],
-      ["firstItemRateAttribute", ["ChannelAdvisor::InventoryServiceSOAP::ShippingRateAttribute", XSD::QName.new(NsWebservices, "FirstItemRateAttribute")]],
-      ["firstItemHandlingRateAttribute", ["ChannelAdvisor::InventoryServiceSOAP::HandlingRateAttribute", XSD::QName.new(NsWebservices, "FirstItemHandlingRateAttribute")], [0, 1]],
-      ["additionalItemRateAttribute", ["ChannelAdvisor::InventoryServiceSOAP::ShippingRateAttribute", XSD::QName.new(NsWebservices, "AdditionalItemRateAttribute")]],
-      ["additionalItemHandlingRateAttribute", ["ChannelAdvisor::InventoryServiceSOAP::HandlingRateAttribute", XSD::QName.new(NsWebservices, "AdditionalItemHandlingRateAttribute")], [0, 1]]
-    ]
-  )
-
-  EncodedRegistry.register(
     :class => ChannelAdvisor::InventoryServiceSOAP::InventoryItemCriteria,
     :schema_type => XSD::QName.new(NsWebservices, "InventoryItemCriteria"),
     :schema_element => [
-      ["dateRangeField", ["ChannelAdvisor::InventoryServiceSOAP::InventoryItemDateRangeField", XSD::QName.new(NsWebservices, "DateRangeField")]],
+      ["dateRangeField", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "DateRangeField")], [0, 1]],
       ["dateRangeStartGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsWebservices, "DateRangeStartGMT")]],
       ["dateRangeEndGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsWebservices, "DateRangeEndGMT")]],
       ["partialSku", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "PartialSku")], [0, 1]],
@@ -288,8 +301,8 @@ module DefaultMappingRegistry
       ["skuEndsWith", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "SkuEndsWith")], [0, 1]],
       ["classificationName", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "ClassificationName")], [0, 1]],
       ["labelName", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "LabelName")], [0, 1]],
-      ["quantityCheckField", ["ChannelAdvisor::InventoryServiceSOAP::InventoryItemQuantityField", XSD::QName.new(NsWebservices, "QuantityCheckField")]],
-      ["quantityCheckType", ["ChannelAdvisor::InventoryServiceSOAP::NumericFilterType", XSD::QName.new(NsWebservices, "QuantityCheckType")]],
+      ["quantityCheckField", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "QuantityCheckField")], [0, 1]],
+      ["quantityCheckType", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "QuantityCheckType")], [0, 1]],
       ["quantityCheckValue", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "QuantityCheckValue")]],
       ["pageNumber", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "PageNumber")]],
       ["pageSize", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "PageSize")]]
@@ -319,14 +332,14 @@ module DefaultMappingRegistry
   )
 
   EncodedRegistry.register(
-    :class => ChannelAdvisor::InventoryServiceSOAP::APIResultOfArrayOfShippingRateInfo,
-    :schema_type => XSD::QName.new(NsWebservices, "APIResultOfArrayOfShippingRateInfo"),
+    :class => ChannelAdvisor::InventoryServiceSOAP::APIResultOfArrayOfDistributionCenterInfoResponse,
+    :schema_type => XSD::QName.new(NsWebservices, "APIResultOfArrayOfDistributionCenterInfoResponse"),
     :schema_element => [
       ["status", ["ChannelAdvisor::InventoryServiceSOAP::ResultStatus", XSD::QName.new(NsWebservices, "Status")]],
       ["messageCode", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "MessageCode")]],
       ["message", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Message")], [0, 1]],
       ["data", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Data")], [0, 1]],
-      ["resultData", ["ChannelAdvisor::InventoryServiceSOAP::ArrayOfShippingRateInfo", XSD::QName.new(NsWebservices, "ResultData")], [0, 1]]
+      ["resultData", ["ChannelAdvisor::InventoryServiceSOAP::ArrayOfDistributionCenterInfoResponse", XSD::QName.new(NsWebservices, "ResultData")], [0, 1]]
     ]
   )
 
@@ -475,8 +488,51 @@ module DefaultMappingRegistry
     :schema_element => [
       ["sKU", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "SKU")], [0, 1]],
       ["quantity", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "Quantity")]],
-      ["messageCode", ["ChannelAdvisor::InventoryServiceSOAP::ErrorCode", XSD::QName.new(NsWebservices, "MessageCode")]],
+      ["messageCode", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "MessageCode")]],
       ["message", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Message")], [0, 1]]
+    ]
+  )
+
+  EncodedRegistry.register(
+    :class => ChannelAdvisor::InventoryServiceSOAP::APIResultOfArrayOfDistributionCenterResponse,
+    :schema_type => XSD::QName.new(NsWebservices, "APIResultOfArrayOfDistributionCenterResponse"),
+    :schema_element => [
+      ["status", ["ChannelAdvisor::InventoryServiceSOAP::ResultStatus", XSD::QName.new(NsWebservices, "Status")]],
+      ["messageCode", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "MessageCode")]],
+      ["message", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Message")], [0, 1]],
+      ["data", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Data")], [0, 1]],
+      ["resultData", ["ChannelAdvisor::InventoryServiceSOAP::ArrayOfDistributionCenterResponse", XSD::QName.new(NsWebservices, "ResultData")], [0, 1]]
+    ]
+  )
+
+  EncodedRegistry.register(
+    :class => ChannelAdvisor::InventoryServiceSOAP::ArrayOfDistributionCenterResponse,
+    :schema_type => XSD::QName.new(NsWebservices, "ArrayOfDistributionCenterResponse"),
+    :schema_element => [
+      ["distributionCenterResponse", ["ChannelAdvisor::InventoryServiceSOAP::DistributionCenterResponse[]", XSD::QName.new(NsWebservices, "DistributionCenterResponse")], [0, nil]]
+    ]
+  )
+
+  EncodedRegistry.register(
+    :class => ChannelAdvisor::InventoryServiceSOAP::DistributionCenterResponse,
+    :schema_type => XSD::QName.new(NsWebservices, "DistributionCenterResponse"),
+    :schema_element => [
+      ["distributionCenterCode", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "DistributionCenterCode")], [0, 1]],
+      ["distributionCenterName", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "DistributionCenterName")], [0, 1]],
+      ["distributionCenterType", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "DistributionCenterType")], [0, 1]],
+      ["contactName", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "ContactName")], [0, 1]],
+      ["contactEmail", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "ContactEmail")], [0, 1]],
+      ["contactPhone", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "ContactPhone")], [0, 1]],
+      ["address1", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Address1")], [0, 1]],
+      ["address2", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Address2")], [0, 1]],
+      ["city", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "City")], [0, 1]],
+      ["regionName", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "RegionName")], [0, 1]],
+      ["countryName", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "CountryName")], [0, 1]],
+      ["postalCode", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "PostalCode")], [0, 1]],
+      ["isDefault", ["SOAP::SOAPBoolean", XSD::QName.new(NsWebservices, "IsDefault")]],
+      ["isExternallyManaged", ["SOAP::SOAPBoolean", XSD::QName.new(NsWebservices, "IsExternallyManaged")]],
+      ["isPickupLocation", ["SOAP::SOAPBoolean", XSD::QName.new(NsWebservices, "IsPickupLocation")]],
+      ["isShipLocation", ["SOAP::SOAPBoolean", XSD::QName.new(NsWebservices, "IsShipLocation")]]
     ]
   )
 
@@ -489,14 +545,15 @@ module DefaultMappingRegistry
       ["subtitle", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Subtitle")], [0, 1]],
       ["shortDescription", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "ShortDescription")], [0, 1]],
       ["description", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Description")], [0, 1]],
-      ["weight", ["SOAP::SOAPDouble", XSD::QName.new(NsWebservices, "Weight")]],
+      ["weight", ["SOAP::SOAPDecimal", XSD::QName.new(NsWebservices, "Weight")]],
       ["supplierCode", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "SupplierCode")], [0, 1]],
       ["warehouseLocation", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "WarehouseLocation")], [0, 1]],
       ["taxProductCode", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "TaxProductCode")], [0, 1]],
-      ["flagStyle", ["ChannelAdvisor::InventoryServiceSOAP::FlagType", XSD::QName.new(NsWebservices, "FlagStyle")]],
+      ["flagStyle", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "FlagStyle")], [0, 1]],
       ["flagDescription", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "FlagDescription")], [0, 1]],
       ["isBlocked", ["SOAP::SOAPBoolean", XSD::QName.new(NsWebservices, "IsBlocked")]],
       ["blockComment", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "BlockComment")], [0, 1]],
+      ["blockExternalQuantity", ["SOAP::SOAPBoolean", XSD::QName.new(NsWebservices, "BlockExternalQuantity")]],
       ["aSIN", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "ASIN")], [0, 1]],
       ["iSBN", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "ISBN")], [0, 1]],
       ["uPC", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "UPC")], [0, 1]],
@@ -508,30 +565,41 @@ module DefaultMappingRegistry
       ["warranty", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Warranty")], [0, 1]],
       ["productMargin", ["SOAP::SOAPDecimal", XSD::QName.new(NsWebservices, "ProductMargin")]],
       ["supplierPO", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "SupplierPO")], [0, 1]],
-      ["receivedInInventory", ["SOAP::SOAPDateTime", XSD::QName.new(NsWebservices, "ReceivedInInventory")]],
       ["harmonizedCode", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "HarmonizedCode")], [0, 1]],
       ["height", ["SOAP::SOAPDecimal", XSD::QName.new(NsWebservices, "Height")]],
       ["length", ["SOAP::SOAPDecimal", XSD::QName.new(NsWebservices, "Length")]],
       ["width", ["SOAP::SOAPDecimal", XSD::QName.new(NsWebservices, "Width")]],
       ["classification", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Classification")], [0, 1]],
-      ["quantityInfo", ["ChannelAdvisor::InventoryServiceSOAP::QuantityInfoSubmit", XSD::QName.new(NsWebservices, "QuantityInfo")], [0, 1]],
+      ["dCQuantityUpdateType", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "DCQuantityUpdateType")], [0, 1]],
+      ["distributionCenterList", ["ChannelAdvisor::InventoryServiceSOAP::ArrayOfDistributionCenterInfoSubmit", XSD::QName.new(NsWebservices, "DistributionCenterList")], [0, 1]],
       ["priceInfo", ["ChannelAdvisor::InventoryServiceSOAP::PriceInfo", XSD::QName.new(NsWebservices, "PriceInfo")], [0, 1]],
       ["attributeList", ["ChannelAdvisor::InventoryServiceSOAP::ArrayOfAttributeInfo", XSD::QName.new(NsWebservices, "AttributeList")], [0, 1]],
       ["variationInfo", ["ChannelAdvisor::InventoryServiceSOAP::VariationInfo", XSD::QName.new(NsWebservices, "VariationInfo")], [0, 1]],
       ["storeInfo", ["ChannelAdvisor::InventoryServiceSOAP::StoreInfo", XSD::QName.new(NsWebservices, "StoreInfo")], [0, 1]],
       ["imageList", ["ChannelAdvisor::InventoryServiceSOAP::ArrayOfImageInfoSubmit", XSD::QName.new(NsWebservices, "ImageList")], [0, 1]],
-      ["shippingInfo", ["ChannelAdvisor::InventoryServiceSOAP::ShippingInfo", XSD::QName.new(NsWebservices, "ShippingInfo")], [0, 1]],
       ["labelList", ["ChannelAdvisor::InventoryServiceSOAP::ArrayOfString", XSD::QName.new(NsWebservices, "LabelList")], [0, 1]],
       ["metaDescription", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "MetaDescription")], [0, 1]]
     ]
   )
 
   EncodedRegistry.register(
-    :class => ChannelAdvisor::InventoryServiceSOAP::QuantityInfoSubmit,
-    :schema_type => XSD::QName.new(NsWebservices, "QuantityInfoSubmit"),
+    :class => ChannelAdvisor::InventoryServiceSOAP::ArrayOfDistributionCenterInfoSubmit,
+    :schema_type => XSD::QName.new(NsWebservices, "ArrayOfDistributionCenterInfoSubmit"),
     :schema_element => [
-      ["updateType", ["ChannelAdvisor::InventoryServiceSOAP::InventoryQuantityUpdateType", XSD::QName.new(NsWebservices, "UpdateType")]],
-      ["total", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "Total")]]
+      ["distributionCenterInfoSubmit", ["ChannelAdvisor::InventoryServiceSOAP::DistributionCenterInfoSubmit[]", XSD::QName.new(NsWebservices, "DistributionCenterInfoSubmit")], [0, nil]]
+    ]
+  )
+
+  EncodedRegistry.register(
+    :class => ChannelAdvisor::InventoryServiceSOAP::DistributionCenterInfoSubmit,
+    :schema_type => XSD::QName.new(NsWebservices, "DistributionCenterInfoSubmit"),
+    :schema_element => [
+      ["distributionCenterCode", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "DistributionCenterCode")], [0, 1]],
+      ["quantity", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "Quantity")]],
+      ["quantityUpdateType", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "QuantityUpdateType")], [0, 1]],
+      ["warehouseLocation", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "WarehouseLocation")], [0, 1]],
+      ["receivedInInventory", ["SOAP::SOAPDateTime", XSD::QName.new(NsWebservices, "ReceivedInInventory")]],
+      ["shippingRateList", ["ChannelAdvisor::InventoryServiceSOAP::ArrayOfShippingRateInfo", XSD::QName.new(NsWebservices, "ShippingRateList")], [0, 1]]
     ]
   )
 
@@ -596,7 +664,9 @@ module DefaultMappingRegistry
     :schema_type => XSD::QName.new(NsWebservices, "InventoryItemQuantityAndPrice"),
     :schema_element => [
       ["sku", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Sku")], [0, 1]],
-      ["quantityInfo", ["ChannelAdvisor::InventoryServiceSOAP::QuantityInfoSubmit", XSD::QName.new(NsWebservices, "QuantityInfo")], [0, 1]],
+      ["distributionCenterCode", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "DistributionCenterCode")], [0, 1]],
+      ["quantity", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "Quantity")]],
+      ["updateType", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "UpdateType")], [0, 1]],
       ["priceInfo", ["ChannelAdvisor::InventoryServiceSOAP::PriceInfo", XSD::QName.new(NsWebservices, "PriceInfo")], [0, 1]]
     ]
   )
@@ -758,56 +828,6 @@ module DefaultMappingRegistry
   EncodedRegistry.register(
     :class => ChannelAdvisor::InventoryServiceSOAP::ResultStatus,
     :schema_type => XSD::QName.new(NsWebservices, "ResultStatus")
-  )
-
-  EncodedRegistry.register(
-    :class => ChannelAdvisor::InventoryServiceSOAP::FlagType,
-    :schema_type => XSD::QName.new(NsWebservices, "FlagType")
-  )
-
-  EncodedRegistry.register(
-    :class => ChannelAdvisor::InventoryServiceSOAP::ShippingRateAttribute,
-    :schema_type => XSD::QName.new(NsWebservices, "ShippingRateAttribute")
-  )
-
-  EncodedRegistry.register(
-    :class => ChannelAdvisor::InventoryServiceSOAP::HandlingRateAttribute,
-    :schema_type => XSD::QName.new(NsWebservices, "HandlingRateAttribute")
-  )
-
-  EncodedRegistry.register(
-    :class => ChannelAdvisor::InventoryServiceSOAP::InventoryItemDateRangeField,
-    :schema_type => XSD::QName.new(NsWebservices, "InventoryItemDateRangeField")
-  )
-
-  EncodedRegistry.register(
-    :class => ChannelAdvisor::InventoryServiceSOAP::InventoryItemQuantityField,
-    :schema_type => XSD::QName.new(NsWebservices, "InventoryItemQuantityField")
-  )
-
-  EncodedRegistry.register(
-    :class => ChannelAdvisor::InventoryServiceSOAP::NumericFilterType,
-    :schema_type => XSD::QName.new(NsWebservices, "NumericFilterType")
-  )
-
-  EncodedRegistry.register(
-    :class => ChannelAdvisor::InventoryServiceSOAP::InventoryItemSortField,
-    :schema_type => XSD::QName.new(NsWebservices, "InventoryItemSortField")
-  )
-
-  EncodedRegistry.register(
-    :class => ChannelAdvisor::InventoryServiceSOAP::SortDirection,
-    :schema_type => XSD::QName.new(NsWebservices, "SortDirection")
-  )
-
-  EncodedRegistry.register(
-    :class => ChannelAdvisor::InventoryServiceSOAP::ErrorCode,
-    :schema_type => XSD::QName.new(NsWebservices, "ErrorCode")
-  )
-
-  EncodedRegistry.register(
-    :class => ChannelAdvisor::InventoryServiceSOAP::InventoryQuantityUpdateType,
-    :schema_type => XSD::QName.new(NsWebservices, "InventoryQuantityUpdateType")
   )
 
   LiteralRegistry.register(
@@ -898,11 +918,11 @@ module DefaultMappingRegistry
       ["subtitle", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Subtitle")], [0, 1]],
       ["shortDescription", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "ShortDescription")], [0, 1]],
       ["description", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Description")], [0, 1]],
-      ["weight", ["SOAP::SOAPDouble", XSD::QName.new(NsWebservices, "Weight")]],
+      ["weight", ["SOAP::SOAPDecimal", XSD::QName.new(NsWebservices, "Weight")]],
       ["supplierCode", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "SupplierCode")], [0, 1]],
       ["warehouseLocation", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "WarehouseLocation")], [0, 1]],
       ["taxProductCode", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "TaxProductCode")], [0, 1]],
-      ["flagStyle", ["ChannelAdvisor::InventoryServiceSOAP::FlagType", XSD::QName.new(NsWebservices, "FlagStyle")]],
+      ["flagStyle", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "FlagStyle")], [0, 1]],
       ["flagDescription", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "FlagDescription")], [0, 1]],
       ["isBlocked", ["SOAP::SOAPBoolean", XSD::QName.new(NsWebservices, "IsBlocked")]],
       ["blockComment", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "BlockComment")], [0, 1]],
@@ -917,20 +937,68 @@ module DefaultMappingRegistry
       ["warranty", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Warranty")], [0, 1]],
       ["productMargin", ["SOAP::SOAPDecimal", XSD::QName.new(NsWebservices, "ProductMargin")]],
       ["supplierPO", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "SupplierPO")], [0, 1]],
-      ["receivedInInventory", ["SOAP::SOAPDateTime", XSD::QName.new(NsWebservices, "ReceivedInInventory")]],
       ["harmonizedCode", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "HarmonizedCode")], [0, 1]],
       ["height", ["SOAP::SOAPDecimal", XSD::QName.new(NsWebservices, "Height")]],
       ["length", ["SOAP::SOAPDecimal", XSD::QName.new(NsWebservices, "Length")]],
       ["width", ["SOAP::SOAPDecimal", XSD::QName.new(NsWebservices, "Width")]],
       ["classification", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Classification")], [0, 1]],
-      ["quantityInfo", ["ChannelAdvisor::InventoryServiceSOAP::QuantityInfoResponse", XSD::QName.new(NsWebservices, "QuantityInfo")], [0, 1]],
+      ["distributionCenterList", ["ChannelAdvisor::InventoryServiceSOAP::ArrayOfDistributionCenterInfoResponse", XSD::QName.new(NsWebservices, "DistributionCenterList")], [0, 1]],
+      ["quantity", ["ChannelAdvisor::InventoryServiceSOAP::QuantityInfoResponse", XSD::QName.new(NsWebservices, "Quantity")], [0, 1]],
       ["priceInfo", ["ChannelAdvisor::InventoryServiceSOAP::PriceInfo", XSD::QName.new(NsWebservices, "PriceInfo")], [0, 1]],
       ["attributeList", ["ChannelAdvisor::InventoryServiceSOAP::ArrayOfAttributeInfo", XSD::QName.new(NsWebservices, "AttributeList")], [0, 1]],
       ["variationInfo", ["ChannelAdvisor::InventoryServiceSOAP::VariationInfo", XSD::QName.new(NsWebservices, "VariationInfo")], [0, 1]],
       ["storeInfo", ["ChannelAdvisor::InventoryServiceSOAP::StoreInfo", XSD::QName.new(NsWebservices, "StoreInfo")], [0, 1]],
       ["imageList", ["ChannelAdvisor::InventoryServiceSOAP::ArrayOfImageInfoResponse", XSD::QName.new(NsWebservices, "ImageList")], [0, 1]],
-      ["shippingInfo", ["ChannelAdvisor::InventoryServiceSOAP::ShippingInfo", XSD::QName.new(NsWebservices, "ShippingInfo")], [0, 1]],
       ["metaDescription", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "MetaDescription")], [0, 1]]
+    ]
+  )
+
+  LiteralRegistry.register(
+    :class => ChannelAdvisor::InventoryServiceSOAP::ArrayOfDistributionCenterInfoResponse,
+    :schema_type => XSD::QName.new(NsWebservices, "ArrayOfDistributionCenterInfoResponse"),
+    :schema_element => [
+      ["distributionCenterInfoResponse", ["ChannelAdvisor::InventoryServiceSOAP::DistributionCenterInfoResponse[]", XSD::QName.new(NsWebservices, "DistributionCenterInfoResponse")], [0, nil]]
+    ]
+  )
+
+  LiteralRegistry.register(
+    :class => ChannelAdvisor::InventoryServiceSOAP::DistributionCenterInfoResponse,
+    :schema_type => XSD::QName.new(NsWebservices, "DistributionCenterInfoResponse"),
+    :schema_element => [
+      ["distributionCenterCode", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "DistributionCenterCode")], [0, 1]],
+      ["availableQuantity", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "AvailableQuantity")]],
+      ["openAllocatedQuantity", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "OpenAllocatedQuantity")]],
+      ["openAllocatedPooledQuantity", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "OpenAllocatedPooledQuantity")]],
+      ["warehouseLocation", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "WarehouseLocation")], [0, 1]],
+      ["receivedInInventory", ["SOAP::SOAPDateTime", XSD::QName.new(NsWebservices, "ReceivedInInventory")]],
+      ["shippingRateList", ["ChannelAdvisor::InventoryServiceSOAP::ArrayOfShippingRateInfo", XSD::QName.new(NsWebservices, "ShippingRateList")], [0, 1]]
+    ]
+  )
+
+  LiteralRegistry.register(
+    :class => ChannelAdvisor::InventoryServiceSOAP::ArrayOfShippingRateInfo,
+    :schema_type => XSD::QName.new(NsWebservices, "ArrayOfShippingRateInfo"),
+    :schema_element => [
+      ["shippingRateInfo", ["ChannelAdvisor::InventoryServiceSOAP::ShippingRateInfo[]", XSD::QName.new(NsWebservices, "ShippingRateInfo")], [0, nil]]
+    ]
+  )
+
+  LiteralRegistry.register(
+    :class => ChannelAdvisor::InventoryServiceSOAP::ShippingRateInfo,
+    :schema_type => XSD::QName.new(NsWebservices, "ShippingRateInfo"),
+    :schema_element => [
+      ["destinationZoneName", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "DestinationZoneName")], [0, 1]],
+      ["carrierCode", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "CarrierCode")], [0, 1]],
+      ["classCode", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "ClassCode")], [0, 1]],
+      ["firstItemRate", ["SOAP::SOAPDecimal", XSD::QName.new(NsWebservices, "FirstItemRate")]],
+      ["additionalItemRate", ["SOAP::SOAPDecimal", XSD::QName.new(NsWebservices, "AdditionalItemRate")]],
+      ["firstItemHandlingRate", ["SOAP::SOAPDecimal", XSD::QName.new(NsWebservices, "FirstItemHandlingRate")]],
+      ["additionalItemHandlingRate", ["SOAP::SOAPDecimal", XSD::QName.new(NsWebservices, "AdditionalItemHandlingRate")]],
+      ["freeShippingIfBuyItNow", ["SOAP::SOAPBoolean", XSD::QName.new(NsWebservices, "FreeShippingIfBuyItNow")]],
+      ["firstItemRateAttribute", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "FirstItemRateAttribute")], [0, 1]],
+      ["firstItemHandlingRateAttribute", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "FirstItemHandlingRateAttribute")], [0, 1]],
+      ["additionalItemRateAttribute", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "AdditionalItemRateAttribute")], [0, 1]],
+      ["additionalItemHandlingRateAttribute", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "AdditionalItemHandlingRateAttribute")], [0, 1]]
     ]
   )
 
@@ -938,14 +1006,15 @@ module DefaultMappingRegistry
     :class => ChannelAdvisor::InventoryServiceSOAP::QuantityInfoResponse,
     :schema_type => XSD::QName.new(NsWebservices, "QuantityInfoResponse"),
     :schema_element => [
-      ["total", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "Total")]],
       ["available", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "Available")]],
-      ["open", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "Open")]],
+      ["openAllocated", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "OpenAllocated")]],
+      ["openUnallocated", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "OpenUnallocated")]],
       ["pendingCheckout", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "PendingCheckout")]],
       ["pendingPayment", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "PendingPayment")]],
       ["pendingShipment", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "PendingShipment")]],
-      ["isScheduled", ["SOAP::SOAPBoolean", XSD::QName.new(NsWebservices, "IsScheduled")]],
-      ["openPooled", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "OpenPooled")]],
+      ["total", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "Total")]],
+      ["openAllocatedPooled", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "OpenAllocatedPooled")]],
+      ["openUnallocatedPooled", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "OpenUnallocatedPooled")]],
       ["pendingCheckoutPooled", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "PendingCheckoutPooled")]],
       ["pendingPaymentPooled", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "PendingPaymentPooled")]],
       ["pendingShipmentPooled", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "PendingShipmentPooled")]],
@@ -1043,46 +1112,10 @@ module DefaultMappingRegistry
   )
 
   LiteralRegistry.register(
-    :class => ChannelAdvisor::InventoryServiceSOAP::ShippingInfo,
-    :schema_type => XSD::QName.new(NsWebservices, "ShippingInfo"),
-    :schema_element => [
-      ["distributionCenterCode", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "DistributionCenterCode")], [0, 1]],
-      ["shippingRateList", ["ChannelAdvisor::InventoryServiceSOAP::ArrayOfShippingRateInfo", XSD::QName.new(NsWebservices, "ShippingRateList")], [0, 1]]
-    ]
-  )
-
-  LiteralRegistry.register(
-    :class => ChannelAdvisor::InventoryServiceSOAP::ArrayOfShippingRateInfo,
-    :schema_type => XSD::QName.new(NsWebservices, "ArrayOfShippingRateInfo"),
-    :schema_element => [
-      ["shippingRateInfo", ["ChannelAdvisor::InventoryServiceSOAP::ShippingRateInfo[]", XSD::QName.new(NsWebservices, "ShippingRateInfo")], [0, nil]]
-    ]
-  )
-
-  LiteralRegistry.register(
-    :class => ChannelAdvisor::InventoryServiceSOAP::ShippingRateInfo,
-    :schema_type => XSD::QName.new(NsWebservices, "ShippingRateInfo"),
-    :schema_element => [
-      ["destinationZoneName", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "DestinationZoneName")], [0, 1]],
-      ["carrierCode", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "CarrierCode")], [0, 1]],
-      ["classCode", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "ClassCode")], [0, 1]],
-      ["firstItemRate", ["SOAP::SOAPDecimal", XSD::QName.new(NsWebservices, "FirstItemRate")]],
-      ["additionalItemRate", ["SOAP::SOAPDecimal", XSD::QName.new(NsWebservices, "AdditionalItemRate")]],
-      ["firstItemHandlingRate", ["SOAP::SOAPDecimal", XSD::QName.new(NsWebservices, "FirstItemHandlingRate")]],
-      ["additionalItemHandlingRate", ["SOAP::SOAPDecimal", XSD::QName.new(NsWebservices, "AdditionalItemHandlingRate")]],
-      ["freeShippingIfBuyItNow", ["SOAP::SOAPBoolean", XSD::QName.new(NsWebservices, "FreeShippingIfBuyItNow")]],
-      ["firstItemRateAttribute", ["ChannelAdvisor::InventoryServiceSOAP::ShippingRateAttribute", XSD::QName.new(NsWebservices, "FirstItemRateAttribute")]],
-      ["firstItemHandlingRateAttribute", ["ChannelAdvisor::InventoryServiceSOAP::HandlingRateAttribute", XSD::QName.new(NsWebservices, "FirstItemHandlingRateAttribute")], [0, 1]],
-      ["additionalItemRateAttribute", ["ChannelAdvisor::InventoryServiceSOAP::ShippingRateAttribute", XSD::QName.new(NsWebservices, "AdditionalItemRateAttribute")]],
-      ["additionalItemHandlingRateAttribute", ["ChannelAdvisor::InventoryServiceSOAP::HandlingRateAttribute", XSD::QName.new(NsWebservices, "AdditionalItemHandlingRateAttribute")], [0, 1]]
-    ]
-  )
-
-  LiteralRegistry.register(
     :class => ChannelAdvisor::InventoryServiceSOAP::InventoryItemCriteria,
     :schema_type => XSD::QName.new(NsWebservices, "InventoryItemCriteria"),
     :schema_element => [
-      ["dateRangeField", ["ChannelAdvisor::InventoryServiceSOAP::InventoryItemDateRangeField", XSD::QName.new(NsWebservices, "DateRangeField")]],
+      ["dateRangeField", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "DateRangeField")], [0, 1]],
       ["dateRangeStartGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsWebservices, "DateRangeStartGMT")]],
       ["dateRangeEndGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsWebservices, "DateRangeEndGMT")]],
       ["partialSku", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "PartialSku")], [0, 1]],
@@ -1090,8 +1123,8 @@ module DefaultMappingRegistry
       ["skuEndsWith", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "SkuEndsWith")], [0, 1]],
       ["classificationName", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "ClassificationName")], [0, 1]],
       ["labelName", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "LabelName")], [0, 1]],
-      ["quantityCheckField", ["ChannelAdvisor::InventoryServiceSOAP::InventoryItemQuantityField", XSD::QName.new(NsWebservices, "QuantityCheckField")]],
-      ["quantityCheckType", ["ChannelAdvisor::InventoryServiceSOAP::NumericFilterType", XSD::QName.new(NsWebservices, "QuantityCheckType")]],
+      ["quantityCheckField", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "QuantityCheckField")], [0, 1]],
+      ["quantityCheckType", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "QuantityCheckType")], [0, 1]],
       ["quantityCheckValue", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "QuantityCheckValue")]],
       ["pageNumber", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "PageNumber")]],
       ["pageSize", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "PageSize")]]
@@ -1121,14 +1154,14 @@ module DefaultMappingRegistry
   )
 
   LiteralRegistry.register(
-    :class => ChannelAdvisor::InventoryServiceSOAP::APIResultOfArrayOfShippingRateInfo,
-    :schema_type => XSD::QName.new(NsWebservices, "APIResultOfArrayOfShippingRateInfo"),
+    :class => ChannelAdvisor::InventoryServiceSOAP::APIResultOfArrayOfDistributionCenterInfoResponse,
+    :schema_type => XSD::QName.new(NsWebservices, "APIResultOfArrayOfDistributionCenterInfoResponse"),
     :schema_element => [
       ["status", ["ChannelAdvisor::InventoryServiceSOAP::ResultStatus", XSD::QName.new(NsWebservices, "Status")]],
       ["messageCode", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "MessageCode")]],
       ["message", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Message")], [0, 1]],
       ["data", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Data")], [0, 1]],
-      ["resultData", ["ChannelAdvisor::InventoryServiceSOAP::ArrayOfShippingRateInfo", XSD::QName.new(NsWebservices, "ResultData")], [0, 1]]
+      ["resultData", ["ChannelAdvisor::InventoryServiceSOAP::ArrayOfDistributionCenterInfoResponse", XSD::QName.new(NsWebservices, "ResultData")], [0, 1]]
     ]
   )
 
@@ -1277,8 +1310,51 @@ module DefaultMappingRegistry
     :schema_element => [
       ["sKU", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "SKU")], [0, 1]],
       ["quantity", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "Quantity")]],
-      ["messageCode", ["ChannelAdvisor::InventoryServiceSOAP::ErrorCode", XSD::QName.new(NsWebservices, "MessageCode")]],
+      ["messageCode", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "MessageCode")]],
       ["message", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Message")], [0, 1]]
+    ]
+  )
+
+  LiteralRegistry.register(
+    :class => ChannelAdvisor::InventoryServiceSOAP::APIResultOfArrayOfDistributionCenterResponse,
+    :schema_type => XSD::QName.new(NsWebservices, "APIResultOfArrayOfDistributionCenterResponse"),
+    :schema_element => [
+      ["status", ["ChannelAdvisor::InventoryServiceSOAP::ResultStatus", XSD::QName.new(NsWebservices, "Status")]],
+      ["messageCode", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "MessageCode")]],
+      ["message", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Message")], [0, 1]],
+      ["data", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Data")], [0, 1]],
+      ["resultData", ["ChannelAdvisor::InventoryServiceSOAP::ArrayOfDistributionCenterResponse", XSD::QName.new(NsWebservices, "ResultData")], [0, 1]]
+    ]
+  )
+
+  LiteralRegistry.register(
+    :class => ChannelAdvisor::InventoryServiceSOAP::ArrayOfDistributionCenterResponse,
+    :schema_type => XSD::QName.new(NsWebservices, "ArrayOfDistributionCenterResponse"),
+    :schema_element => [
+      ["distributionCenterResponse", ["ChannelAdvisor::InventoryServiceSOAP::DistributionCenterResponse[]", XSD::QName.new(NsWebservices, "DistributionCenterResponse")], [0, nil]]
+    ]
+  )
+
+  LiteralRegistry.register(
+    :class => ChannelAdvisor::InventoryServiceSOAP::DistributionCenterResponse,
+    :schema_type => XSD::QName.new(NsWebservices, "DistributionCenterResponse"),
+    :schema_element => [
+      ["distributionCenterCode", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "DistributionCenterCode")], [0, 1]],
+      ["distributionCenterName", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "DistributionCenterName")], [0, 1]],
+      ["distributionCenterType", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "DistributionCenterType")], [0, 1]],
+      ["contactName", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "ContactName")], [0, 1]],
+      ["contactEmail", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "ContactEmail")], [0, 1]],
+      ["contactPhone", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "ContactPhone")], [0, 1]],
+      ["address1", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Address1")], [0, 1]],
+      ["address2", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Address2")], [0, 1]],
+      ["city", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "City")], [0, 1]],
+      ["regionName", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "RegionName")], [0, 1]],
+      ["countryName", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "CountryName")], [0, 1]],
+      ["postalCode", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "PostalCode")], [0, 1]],
+      ["isDefault", ["SOAP::SOAPBoolean", XSD::QName.new(NsWebservices, "IsDefault")]],
+      ["isExternallyManaged", ["SOAP::SOAPBoolean", XSD::QName.new(NsWebservices, "IsExternallyManaged")]],
+      ["isPickupLocation", ["SOAP::SOAPBoolean", XSD::QName.new(NsWebservices, "IsPickupLocation")]],
+      ["isShipLocation", ["SOAP::SOAPBoolean", XSD::QName.new(NsWebservices, "IsShipLocation")]]
     ]
   )
 
@@ -1291,14 +1367,15 @@ module DefaultMappingRegistry
       ["subtitle", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Subtitle")], [0, 1]],
       ["shortDescription", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "ShortDescription")], [0, 1]],
       ["description", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Description")], [0, 1]],
-      ["weight", ["SOAP::SOAPDouble", XSD::QName.new(NsWebservices, "Weight")]],
+      ["weight", ["SOAP::SOAPDecimal", XSD::QName.new(NsWebservices, "Weight")]],
       ["supplierCode", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "SupplierCode")], [0, 1]],
       ["warehouseLocation", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "WarehouseLocation")], [0, 1]],
       ["taxProductCode", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "TaxProductCode")], [0, 1]],
-      ["flagStyle", ["ChannelAdvisor::InventoryServiceSOAP::FlagType", XSD::QName.new(NsWebservices, "FlagStyle")]],
+      ["flagStyle", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "FlagStyle")], [0, 1]],
       ["flagDescription", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "FlagDescription")], [0, 1]],
       ["isBlocked", ["SOAP::SOAPBoolean", XSD::QName.new(NsWebservices, "IsBlocked")]],
       ["blockComment", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "BlockComment")], [0, 1]],
+      ["blockExternalQuantity", ["SOAP::SOAPBoolean", XSD::QName.new(NsWebservices, "BlockExternalQuantity")]],
       ["aSIN", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "ASIN")], [0, 1]],
       ["iSBN", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "ISBN")], [0, 1]],
       ["uPC", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "UPC")], [0, 1]],
@@ -1310,30 +1387,41 @@ module DefaultMappingRegistry
       ["warranty", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Warranty")], [0, 1]],
       ["productMargin", ["SOAP::SOAPDecimal", XSD::QName.new(NsWebservices, "ProductMargin")]],
       ["supplierPO", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "SupplierPO")], [0, 1]],
-      ["receivedInInventory", ["SOAP::SOAPDateTime", XSD::QName.new(NsWebservices, "ReceivedInInventory")]],
       ["harmonizedCode", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "HarmonizedCode")], [0, 1]],
       ["height", ["SOAP::SOAPDecimal", XSD::QName.new(NsWebservices, "Height")]],
       ["length", ["SOAP::SOAPDecimal", XSD::QName.new(NsWebservices, "Length")]],
       ["width", ["SOAP::SOAPDecimal", XSD::QName.new(NsWebservices, "Width")]],
       ["classification", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Classification")], [0, 1]],
-      ["quantityInfo", ["ChannelAdvisor::InventoryServiceSOAP::QuantityInfoSubmit", XSD::QName.new(NsWebservices, "QuantityInfo")], [0, 1]],
+      ["dCQuantityUpdateType", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "DCQuantityUpdateType")], [0, 1]],
+      ["distributionCenterList", ["ChannelAdvisor::InventoryServiceSOAP::ArrayOfDistributionCenterInfoSubmit", XSD::QName.new(NsWebservices, "DistributionCenterList")], [0, 1]],
       ["priceInfo", ["ChannelAdvisor::InventoryServiceSOAP::PriceInfo", XSD::QName.new(NsWebservices, "PriceInfo")], [0, 1]],
       ["attributeList", ["ChannelAdvisor::InventoryServiceSOAP::ArrayOfAttributeInfo", XSD::QName.new(NsWebservices, "AttributeList")], [0, 1]],
       ["variationInfo", ["ChannelAdvisor::InventoryServiceSOAP::VariationInfo", XSD::QName.new(NsWebservices, "VariationInfo")], [0, 1]],
       ["storeInfo", ["ChannelAdvisor::InventoryServiceSOAP::StoreInfo", XSD::QName.new(NsWebservices, "StoreInfo")], [0, 1]],
       ["imageList", ["ChannelAdvisor::InventoryServiceSOAP::ArrayOfImageInfoSubmit", XSD::QName.new(NsWebservices, "ImageList")], [0, 1]],
-      ["shippingInfo", ["ChannelAdvisor::InventoryServiceSOAP::ShippingInfo", XSD::QName.new(NsWebservices, "ShippingInfo")], [0, 1]],
       ["labelList", ["ChannelAdvisor::InventoryServiceSOAP::ArrayOfString", XSD::QName.new(NsWebservices, "LabelList")], [0, 1]],
       ["metaDescription", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "MetaDescription")], [0, 1]]
     ]
   )
 
   LiteralRegistry.register(
-    :class => ChannelAdvisor::InventoryServiceSOAP::QuantityInfoSubmit,
-    :schema_type => XSD::QName.new(NsWebservices, "QuantityInfoSubmit"),
+    :class => ChannelAdvisor::InventoryServiceSOAP::ArrayOfDistributionCenterInfoSubmit,
+    :schema_type => XSD::QName.new(NsWebservices, "ArrayOfDistributionCenterInfoSubmit"),
     :schema_element => [
-      ["updateType", ["ChannelAdvisor::InventoryServiceSOAP::InventoryQuantityUpdateType", XSD::QName.new(NsWebservices, "UpdateType")]],
-      ["total", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "Total")]]
+      ["distributionCenterInfoSubmit", ["ChannelAdvisor::InventoryServiceSOAP::DistributionCenterInfoSubmit[]", XSD::QName.new(NsWebservices, "DistributionCenterInfoSubmit")], [0, nil]]
+    ]
+  )
+
+  LiteralRegistry.register(
+    :class => ChannelAdvisor::InventoryServiceSOAP::DistributionCenterInfoSubmit,
+    :schema_type => XSD::QName.new(NsWebservices, "DistributionCenterInfoSubmit"),
+    :schema_element => [
+      ["distributionCenterCode", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "DistributionCenterCode")], [0, 1]],
+      ["quantity", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "Quantity")]],
+      ["quantityUpdateType", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "QuantityUpdateType")], [0, 1]],
+      ["warehouseLocation", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "WarehouseLocation")], [0, 1]],
+      ["receivedInInventory", ["SOAP::SOAPDateTime", XSD::QName.new(NsWebservices, "ReceivedInInventory")]],
+      ["shippingRateList", ["ChannelAdvisor::InventoryServiceSOAP::ArrayOfShippingRateInfo", XSD::QName.new(NsWebservices, "ShippingRateList")], [0, 1]]
     ]
   )
 
@@ -1398,7 +1486,9 @@ module DefaultMappingRegistry
     :schema_type => XSD::QName.new(NsWebservices, "InventoryItemQuantityAndPrice"),
     :schema_element => [
       ["sku", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Sku")], [0, 1]],
-      ["quantityInfo", ["ChannelAdvisor::InventoryServiceSOAP::QuantityInfoSubmit", XSD::QName.new(NsWebservices, "QuantityInfo")], [0, 1]],
+      ["distributionCenterCode", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "DistributionCenterCode")], [0, 1]],
+      ["quantity", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "Quantity")]],
+      ["updateType", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "UpdateType")], [0, 1]],
       ["priceInfo", ["ChannelAdvisor::InventoryServiceSOAP::PriceInfo", XSD::QName.new(NsWebservices, "PriceInfo")], [0, 1]]
     ]
   )
@@ -1563,61 +1653,11 @@ module DefaultMappingRegistry
   )
 
   LiteralRegistry.register(
-    :class => ChannelAdvisor::InventoryServiceSOAP::FlagType,
-    :schema_type => XSD::QName.new(NsWebservices, "FlagType")
-  )
-
-  LiteralRegistry.register(
-    :class => ChannelAdvisor::InventoryServiceSOAP::ShippingRateAttribute,
-    :schema_type => XSD::QName.new(NsWebservices, "ShippingRateAttribute")
-  )
-
-  LiteralRegistry.register(
-    :class => ChannelAdvisor::InventoryServiceSOAP::HandlingRateAttribute,
-    :schema_type => XSD::QName.new(NsWebservices, "HandlingRateAttribute")
-  )
-
-  LiteralRegistry.register(
-    :class => ChannelAdvisor::InventoryServiceSOAP::InventoryItemDateRangeField,
-    :schema_type => XSD::QName.new(NsWebservices, "InventoryItemDateRangeField")
-  )
-
-  LiteralRegistry.register(
-    :class => ChannelAdvisor::InventoryServiceSOAP::InventoryItemQuantityField,
-    :schema_type => XSD::QName.new(NsWebservices, "InventoryItemQuantityField")
-  )
-
-  LiteralRegistry.register(
-    :class => ChannelAdvisor::InventoryServiceSOAP::NumericFilterType,
-    :schema_type => XSD::QName.new(NsWebservices, "NumericFilterType")
-  )
-
-  LiteralRegistry.register(
-    :class => ChannelAdvisor::InventoryServiceSOAP::InventoryItemSortField,
-    :schema_type => XSD::QName.new(NsWebservices, "InventoryItemSortField")
-  )
-
-  LiteralRegistry.register(
-    :class => ChannelAdvisor::InventoryServiceSOAP::SortDirection,
-    :schema_type => XSD::QName.new(NsWebservices, "SortDirection")
-  )
-
-  LiteralRegistry.register(
-    :class => ChannelAdvisor::InventoryServiceSOAP::ErrorCode,
-    :schema_type => XSD::QName.new(NsWebservices, "ErrorCode")
-  )
-
-  LiteralRegistry.register(
-    :class => ChannelAdvisor::InventoryServiceSOAP::InventoryQuantityUpdateType,
-    :schema_type => XSD::QName.new(NsWebservices, "InventoryQuantityUpdateType")
-  )
-
-  LiteralRegistry.register(
     :class => ChannelAdvisor::InventoryServiceSOAP::DoesSkuExist,
     :schema_name => XSD::QName.new(NsWebservices, "DoesSkuExist"),
     :schema_element => [
       ["accountID", "SOAP::SOAPString"],
-      ["sku", "SOAP::SOAPString", [0, 1]]
+      ["sku", "SOAP::SOAPString"]
     ]
   )
 
@@ -1686,10 +1726,10 @@ module DefaultMappingRegistry
     :schema_name => XSD::QName.new(NsWebservices, "GetFilteredInventoryItemList"),
     :schema_element => [
       ["accountID", "SOAP::SOAPString"],
-      ["itemCriteria", "ChannelAdvisor::InventoryServiceSOAP::InventoryItemCriteria", [0, 1]],
+      ["itemCriteria", "ChannelAdvisor::InventoryServiceSOAP::InventoryItemCriteria"],
       ["detailLevel", "ChannelAdvisor::InventoryServiceSOAP::InventoryItemDetailLevel", [0, 1]],
-      ["sortField", "ChannelAdvisor::InventoryServiceSOAP::InventoryItemSortField"],
-      ["sortDirection", "ChannelAdvisor::InventoryServiceSOAP::SortDirection"]
+      ["sortField", "SOAP::SOAPString", [0, 1]],
+      ["sortDirection", "SOAP::SOAPString", [0, 1]]
     ]
   )
 
@@ -1706,9 +1746,9 @@ module DefaultMappingRegistry
     :schema_name => XSD::QName.new(NsWebservices, "GetFilteredSkuList"),
     :schema_element => [
       ["accountID", "SOAP::SOAPString"],
-      ["itemCriteria", "ChannelAdvisor::InventoryServiceSOAP::InventoryItemCriteria", [0, 1]],
-      ["sortField", "ChannelAdvisor::InventoryServiceSOAP::InventoryItemSortField"],
-      ["sortDirection", "ChannelAdvisor::InventoryServiceSOAP::SortDirection"]
+      ["itemCriteria", "ChannelAdvisor::InventoryServiceSOAP::InventoryItemCriteria"],
+      ["sortField", "SOAP::SOAPString", [0, 1]],
+      ["sortDirection", "SOAP::SOAPString", [0, 1]]
     ]
   )
 
@@ -1725,7 +1765,7 @@ module DefaultMappingRegistry
     :schema_name => XSD::QName.new(NsWebservices, "GetInventoryItemShippingInfo"),
     :schema_element => [
       ["accountID", "SOAP::SOAPString"],
-      ["sku", "SOAP::SOAPString", [0, 1]]
+      ["sku", "SOAP::SOAPString"]
     ]
   )
 
@@ -1733,7 +1773,7 @@ module DefaultMappingRegistry
     :class => ChannelAdvisor::InventoryServiceSOAP::GetInventoryItemShippingInfoResponse,
     :schema_name => XSD::QName.new(NsWebservices, "GetInventoryItemShippingInfoResponse"),
     :schema_element => [
-      ["getInventoryItemShippingInfoResult", ["ChannelAdvisor::InventoryServiceSOAP::APIResultOfArrayOfShippingRateInfo", XSD::QName.new(NsWebservices, "GetInventoryItemShippingInfoResult")], [0, 1]]
+      ["getInventoryItemShippingInfoResult", ["ChannelAdvisor::InventoryServiceSOAP::APIResultOfArrayOfDistributionCenterInfoResponse", XSD::QName.new(NsWebservices, "GetInventoryItemShippingInfoResult")], [0, 1]]
     ]
   )
 
@@ -1742,7 +1782,7 @@ module DefaultMappingRegistry
     :schema_name => XSD::QName.new(NsWebservices, "GetInventoryItemQuantityInfo"),
     :schema_element => [
       ["accountID", "SOAP::SOAPString"],
-      ["sku", "SOAP::SOAPString", [0, 1]]
+      ["sku", "SOAP::SOAPString"]
     ]
   )
 
@@ -1775,7 +1815,7 @@ module DefaultMappingRegistry
     :schema_name => XSD::QName.new(NsWebservices, "GetInventoryItemAttributeList"),
     :schema_element => [
       ["accountID", "SOAP::SOAPString"],
-      ["sku", "SOAP::SOAPString", [0, 1]]
+      ["sku", "SOAP::SOAPString"]
     ]
   )
 
@@ -1792,7 +1832,7 @@ module DefaultMappingRegistry
     :schema_name => XSD::QName.new(NsWebservices, "GetInventoryItemVariationInfo"),
     :schema_element => [
       ["accountID", "SOAP::SOAPString"],
-      ["sku", "SOAP::SOAPString", [0, 1]]
+      ["sku", "SOAP::SOAPString"]
     ]
   )
 
@@ -1809,7 +1849,7 @@ module DefaultMappingRegistry
     :schema_name => XSD::QName.new(NsWebservices, "GetInventoryItemStoreInfo"),
     :schema_element => [
       ["accountID", "SOAP::SOAPString"],
-      ["sku", "SOAP::SOAPString", [0, 1]]
+      ["sku", "SOAP::SOAPString"]
     ]
   )
 
@@ -1826,7 +1866,7 @@ module DefaultMappingRegistry
     :schema_name => XSD::QName.new(NsWebservices, "GetInventoryItemImageList"),
     :schema_element => [
       ["accountID", "SOAP::SOAPString"],
-      ["sku", "SOAP::SOAPString", [0, 1]]
+      ["sku", "SOAP::SOAPString"]
     ]
   )
 
@@ -1843,7 +1883,7 @@ module DefaultMappingRegistry
     :schema_name => XSD::QName.new(NsWebservices, "GetInventoryQuantity"),
     :schema_element => [
       ["accountID", "SOAP::SOAPString"],
-      ["sku", "SOAP::SOAPString", [0, 1]]
+      ["sku", "SOAP::SOAPString"]
     ]
   )
 
@@ -1873,11 +1913,27 @@ module DefaultMappingRegistry
   )
 
   LiteralRegistry.register(
+    :class => ChannelAdvisor::InventoryServiceSOAP::GetDistributionCenterList,
+    :schema_name => XSD::QName.new(NsWebservices, "GetDistributionCenterList"),
+    :schema_element => [
+      ["accountID", "SOAP::SOAPString"]
+    ]
+  )
+
+  LiteralRegistry.register(
+    :class => ChannelAdvisor::InventoryServiceSOAP::GetDistributionCenterListResponse,
+    :schema_name => XSD::QName.new(NsWebservices, "GetDistributionCenterListResponse"),
+    :schema_element => [
+      ["getDistributionCenterListResult", ["ChannelAdvisor::InventoryServiceSOAP::APIResultOfArrayOfDistributionCenterResponse", XSD::QName.new(NsWebservices, "GetDistributionCenterListResult")], [0, 1]]
+    ]
+  )
+
+  LiteralRegistry.register(
     :class => ChannelAdvisor::InventoryServiceSOAP::DeleteInventoryItem,
     :schema_name => XSD::QName.new(NsWebservices, "DeleteInventoryItem"),
     :schema_element => [
       ["accountID", "SOAP::SOAPString"],
-      ["sku", "SOAP::SOAPString", [0, 1]]
+      ["sku", "SOAP::SOAPString"]
     ]
   )
 
@@ -1894,7 +1950,7 @@ module DefaultMappingRegistry
     :schema_name => XSD::QName.new(NsWebservices, "SynchInventoryItem"),
     :schema_element => [
       ["accountID", "SOAP::SOAPString"],
-      ["item", "ChannelAdvisor::InventoryServiceSOAP::InventoryItemSubmit", [0, 1]]
+      ["item", "ChannelAdvisor::InventoryServiceSOAP::InventoryItemSubmit"]
     ]
   )
 
@@ -1920,7 +1976,7 @@ module DefaultMappingRegistry
     :schema_name => XSD::QName.new(NsWebservices, "UpdateInventoryItemQuantityAndPrice"),
     :schema_element => [
       ["accountID", "SOAP::SOAPString"],
-      ["itemQuantityAndPrice", "ChannelAdvisor::InventoryServiceSOAP::InventoryItemQuantityAndPrice", [0, 1]]
+      ["itemQuantityAndPrice", "ChannelAdvisor::InventoryServiceSOAP::InventoryItemQuantityAndPrice"]
     ]
   )
 
@@ -2027,7 +2083,7 @@ module DefaultMappingRegistry
     :schema_name => XSD::QName.new(NsWebservices, "DeleteUpsellRelationship"),
     :schema_element => [
       ["accountID", "SOAP::SOAPString"],
-      ["parentSKU", "SOAP::SOAPString", [0, 1]],
+      ["parentSKU", "SOAP::SOAPString"],
       ["childSKUList", "ChannelAdvisor::InventoryServiceSOAP::ArrayOfString", [0, 1]]
     ]
   )

--- a/lib/channel_advisor/inventory_service/types.rb
+++ b/lib/channel_advisor/inventory_service/types.rb
@@ -116,11 +116,11 @@ end
 #   subtitle - SOAP::SOAPString
 #   shortDescription - SOAP::SOAPString
 #   description - SOAP::SOAPString
-#   weight - SOAP::SOAPDouble
+#   weight - SOAP::SOAPDecimal
 #   supplierCode - SOAP::SOAPString
 #   warehouseLocation - SOAP::SOAPString
 #   taxProductCode - SOAP::SOAPString
-#   flagStyle - ChannelAdvisor::InventoryServiceSOAP::FlagType
+#   flagStyle - SOAP::SOAPString
 #   flagDescription - SOAP::SOAPString
 #   isBlocked - SOAP::SOAPBoolean
 #   blockComment - SOAP::SOAPString
@@ -135,19 +135,18 @@ end
 #   warranty - SOAP::SOAPString
 #   productMargin - SOAP::SOAPDecimal
 #   supplierPO - SOAP::SOAPString
-#   receivedInInventory - SOAP::SOAPDateTime
 #   harmonizedCode - SOAP::SOAPString
 #   height - SOAP::SOAPDecimal
 #   length - SOAP::SOAPDecimal
 #   width - SOAP::SOAPDecimal
 #   classification - SOAP::SOAPString
-#   quantityInfo - ChannelAdvisor::InventoryServiceSOAP::QuantityInfoResponse
+#   distributionCenterList - ChannelAdvisor::InventoryServiceSOAP::ArrayOfDistributionCenterInfoResponse
+#   quantity - ChannelAdvisor::InventoryServiceSOAP::QuantityInfoResponse
 #   priceInfo - ChannelAdvisor::InventoryServiceSOAP::PriceInfo
 #   attributeList - ChannelAdvisor::InventoryServiceSOAP::ArrayOfAttributeInfo
 #   variationInfo - ChannelAdvisor::InventoryServiceSOAP::VariationInfo
 #   storeInfo - ChannelAdvisor::InventoryServiceSOAP::StoreInfo
 #   imageList - ChannelAdvisor::InventoryServiceSOAP::ArrayOfImageInfoResponse
-#   shippingInfo - ChannelAdvisor::InventoryServiceSOAP::ShippingInfo
 #   metaDescription - SOAP::SOAPString
 class InventoryItemResponse
   attr_accessor :sku
@@ -174,22 +173,21 @@ class InventoryItemResponse
   attr_accessor :warranty
   attr_accessor :productMargin
   attr_accessor :supplierPO
-  attr_accessor :receivedInInventory
   attr_accessor :harmonizedCode
   attr_accessor :height
   attr_accessor :length
   attr_accessor :width
   attr_accessor :classification
-  attr_accessor :quantityInfo
+  attr_accessor :distributionCenterList
+  attr_accessor :quantity
   attr_accessor :priceInfo
   attr_accessor :attributeList
   attr_accessor :variationInfo
   attr_accessor :storeInfo
   attr_accessor :imageList
-  attr_accessor :shippingInfo
   attr_accessor :metaDescription
 
-  def initialize(sku = nil, title = nil, subtitle = nil, shortDescription = nil, description = nil, weight = nil, supplierCode = nil, warehouseLocation = nil, taxProductCode = nil, flagStyle = nil, flagDescription = nil, isBlocked = nil, blockComment = nil, aSIN = nil, iSBN = nil, uPC = nil, mPN = nil, eAN = nil, manufacturer = nil, brand = nil, condition = nil, warranty = nil, productMargin = nil, supplierPO = nil, receivedInInventory = nil, harmonizedCode = nil, height = nil, length = nil, width = nil, classification = nil, quantityInfo = nil, priceInfo = nil, attributeList = nil, variationInfo = nil, storeInfo = nil, imageList = nil, shippingInfo = nil, metaDescription = nil)
+  def initialize(sku = nil, title = nil, subtitle = nil, shortDescription = nil, description = nil, weight = nil, supplierCode = nil, warehouseLocation = nil, taxProductCode = nil, flagStyle = nil, flagDescription = nil, isBlocked = nil, blockComment = nil, aSIN = nil, iSBN = nil, uPC = nil, mPN = nil, eAN = nil, manufacturer = nil, brand = nil, condition = nil, warranty = nil, productMargin = nil, supplierPO = nil, harmonizedCode = nil, height = nil, length = nil, width = nil, classification = nil, distributionCenterList = nil, quantity = nil, priceInfo = nil, attributeList = nil, variationInfo = nil, storeInfo = nil, imageList = nil, metaDescription = nil)
     @sku = sku
     @title = title
     @subtitle = subtitle
@@ -214,59 +212,140 @@ class InventoryItemResponse
     @warranty = warranty
     @productMargin = productMargin
     @supplierPO = supplierPO
-    @receivedInInventory = receivedInInventory
     @harmonizedCode = harmonizedCode
     @height = height
     @length = length
     @width = width
     @classification = classification
-    @quantityInfo = quantityInfo
+    @distributionCenterList = distributionCenterList
+    @quantity = quantity
     @priceInfo = priceInfo
     @attributeList = attributeList
     @variationInfo = variationInfo
     @storeInfo = storeInfo
     @imageList = imageList
-    @shippingInfo = shippingInfo
     @metaDescription = metaDescription
   end
 end
 
+# {http://api.channeladvisor.com/webservices/}ArrayOfDistributionCenterInfoResponse
+class ArrayOfDistributionCenterInfoResponse < ::Array
+end
+
+# {http://api.channeladvisor.com/webservices/}DistributionCenterInfoResponse
+#   distributionCenterCode - SOAP::SOAPString
+#   availableQuantity - SOAP::SOAPInt
+#   openAllocatedQuantity - SOAP::SOAPInt
+#   openAllocatedPooledQuantity - SOAP::SOAPInt
+#   warehouseLocation - SOAP::SOAPString
+#   receivedInInventory - SOAP::SOAPDateTime
+#   shippingRateList - ChannelAdvisor::InventoryServiceSOAP::ArrayOfShippingRateInfo
+class DistributionCenterInfoResponse
+  attr_accessor :distributionCenterCode
+  attr_accessor :availableQuantity
+  attr_accessor :openAllocatedQuantity
+  attr_accessor :openAllocatedPooledQuantity
+  attr_accessor :warehouseLocation
+  attr_accessor :receivedInInventory
+  attr_accessor :shippingRateList
+
+  def initialize(distributionCenterCode = nil, availableQuantity = nil, openAllocatedQuantity = nil, openAllocatedPooledQuantity = nil, warehouseLocation = nil, receivedInInventory = nil, shippingRateList = nil)
+    @distributionCenterCode = distributionCenterCode
+    @availableQuantity = availableQuantity
+    @openAllocatedQuantity = openAllocatedQuantity
+    @openAllocatedPooledQuantity = openAllocatedPooledQuantity
+    @warehouseLocation = warehouseLocation
+    @receivedInInventory = receivedInInventory
+    @shippingRateList = shippingRateList
+  end
+end
+
+# {http://api.channeladvisor.com/webservices/}ArrayOfShippingRateInfo
+class ArrayOfShippingRateInfo < ::Array
+end
+
+# {http://api.channeladvisor.com/webservices/}ShippingRateInfo
+#   destinationZoneName - SOAP::SOAPString
+#   carrierCode - SOAP::SOAPString
+#   classCode - SOAP::SOAPString
+#   firstItemRate - SOAP::SOAPDecimal
+#   additionalItemRate - SOAP::SOAPDecimal
+#   firstItemHandlingRate - SOAP::SOAPDecimal
+#   additionalItemHandlingRate - SOAP::SOAPDecimal
+#   freeShippingIfBuyItNow - SOAP::SOAPBoolean
+#   firstItemRateAttribute - SOAP::SOAPString
+#   firstItemHandlingRateAttribute - SOAP::SOAPString
+#   additionalItemRateAttribute - SOAP::SOAPString
+#   additionalItemHandlingRateAttribute - SOAP::SOAPString
+class ShippingRateInfo
+  attr_accessor :destinationZoneName
+  attr_accessor :carrierCode
+  attr_accessor :classCode
+  attr_accessor :firstItemRate
+  attr_accessor :additionalItemRate
+  attr_accessor :firstItemHandlingRate
+  attr_accessor :additionalItemHandlingRate
+  attr_accessor :freeShippingIfBuyItNow
+  attr_accessor :firstItemRateAttribute
+  attr_accessor :firstItemHandlingRateAttribute
+  attr_accessor :additionalItemRateAttribute
+  attr_accessor :additionalItemHandlingRateAttribute
+
+  def initialize(destinationZoneName = nil, carrierCode = nil, classCode = nil, firstItemRate = nil, additionalItemRate = nil, firstItemHandlingRate = nil, additionalItemHandlingRate = nil, freeShippingIfBuyItNow = nil, firstItemRateAttribute = nil, firstItemHandlingRateAttribute = nil, additionalItemRateAttribute = nil, additionalItemHandlingRateAttribute = nil)
+    @destinationZoneName = destinationZoneName
+    @carrierCode = carrierCode
+    @classCode = classCode
+    @firstItemRate = firstItemRate
+    @additionalItemRate = additionalItemRate
+    @firstItemHandlingRate = firstItemHandlingRate
+    @additionalItemHandlingRate = additionalItemHandlingRate
+    @freeShippingIfBuyItNow = freeShippingIfBuyItNow
+    @firstItemRateAttribute = firstItemRateAttribute
+    @firstItemHandlingRateAttribute = firstItemHandlingRateAttribute
+    @additionalItemRateAttribute = additionalItemRateAttribute
+    @additionalItemHandlingRateAttribute = additionalItemHandlingRateAttribute
+  end
+end
+
 # {http://api.channeladvisor.com/webservices/}QuantityInfoResponse
-#   total - SOAP::SOAPInt
 #   available - SOAP::SOAPInt
-#   open - SOAP::SOAPInt
+#   openAllocated - SOAP::SOAPInt
+#   openUnallocated - SOAP::SOAPInt
 #   pendingCheckout - SOAP::SOAPInt
 #   pendingPayment - SOAP::SOAPInt
 #   pendingShipment - SOAP::SOAPInt
-#   isScheduled - SOAP::SOAPBoolean
-#   openPooled - SOAP::SOAPInt
+#   total - SOAP::SOAPInt
+#   openAllocatedPooled - SOAP::SOAPInt
+#   openUnallocatedPooled - SOAP::SOAPInt
 #   pendingCheckoutPooled - SOAP::SOAPInt
 #   pendingPaymentPooled - SOAP::SOAPInt
 #   pendingShipmentPooled - SOAP::SOAPInt
 #   totalPooled - SOAP::SOAPInt
 class QuantityInfoResponse
-  attr_accessor :total
   attr_accessor :available
-  attr_accessor :open
+  attr_accessor :openAllocated
+  attr_accessor :openUnallocated
   attr_accessor :pendingCheckout
   attr_accessor :pendingPayment
   attr_accessor :pendingShipment
-  attr_accessor :isScheduled
-  attr_accessor :openPooled
+  attr_accessor :total
+  attr_accessor :openAllocatedPooled
+  attr_accessor :openUnallocatedPooled
   attr_accessor :pendingCheckoutPooled
   attr_accessor :pendingPaymentPooled
   attr_accessor :pendingShipmentPooled
   attr_accessor :totalPooled
 
-  def initialize(total = nil, available = nil, open = nil, pendingCheckout = nil, pendingPayment = nil, pendingShipment = nil, isScheduled = nil, openPooled = nil, pendingCheckoutPooled = nil, pendingPaymentPooled = nil, pendingShipmentPooled = nil, totalPooled = nil)
-    @total = total
+  def initialize(available = nil, openAllocated = nil, openUnallocated = nil, pendingCheckout = nil, pendingPayment = nil, pendingShipment = nil, total = nil, openAllocatedPooled = nil, openUnallocatedPooled = nil, pendingCheckoutPooled = nil, pendingPaymentPooled = nil, pendingShipmentPooled = nil, totalPooled = nil)
     @available = available
-    @open = open
+    @openAllocated = openAllocated
+    @openUnallocated = openUnallocated
     @pendingCheckout = pendingCheckout
     @pendingPayment = pendingPayment
     @pendingShipment = pendingShipment
-    @isScheduled = isScheduled
-    @openPooled = openPooled
+    @total = total
+    @openAllocatedPooled = openAllocatedPooled
+    @openUnallocatedPooled = openUnallocatedPooled
     @pendingCheckoutPooled = pendingCheckoutPooled
     @pendingPaymentPooled = pendingPaymentPooled
     @pendingShipmentPooled = pendingShipmentPooled
@@ -397,68 +476,8 @@ class ImageThumbInfo
   end
 end
 
-# {http://api.channeladvisor.com/webservices/}ShippingInfo
-#   distributionCenterCode - SOAP::SOAPString
-#   shippingRateList - ChannelAdvisor::InventoryServiceSOAP::ArrayOfShippingRateInfo
-class ShippingInfo
-  attr_accessor :distributionCenterCode
-  attr_accessor :shippingRateList
-
-  def initialize(distributionCenterCode = nil, shippingRateList = nil)
-    @distributionCenterCode = distributionCenterCode
-    @shippingRateList = shippingRateList
-  end
-end
-
-# {http://api.channeladvisor.com/webservices/}ArrayOfShippingRateInfo
-class ArrayOfShippingRateInfo < ::Array
-end
-
-# {http://api.channeladvisor.com/webservices/}ShippingRateInfo
-#   destinationZoneName - SOAP::SOAPString
-#   carrierCode - SOAP::SOAPString
-#   classCode - SOAP::SOAPString
-#   firstItemRate - SOAP::SOAPDecimal
-#   additionalItemRate - SOAP::SOAPDecimal
-#   firstItemHandlingRate - SOAP::SOAPDecimal
-#   additionalItemHandlingRate - SOAP::SOAPDecimal
-#   freeShippingIfBuyItNow - SOAP::SOAPBoolean
-#   firstItemRateAttribute - ChannelAdvisor::InventoryServiceSOAP::ShippingRateAttribute
-#   firstItemHandlingRateAttribute - ChannelAdvisor::InventoryServiceSOAP::HandlingRateAttribute
-#   additionalItemRateAttribute - ChannelAdvisor::InventoryServiceSOAP::ShippingRateAttribute
-#   additionalItemHandlingRateAttribute - ChannelAdvisor::InventoryServiceSOAP::HandlingRateAttribute
-class ShippingRateInfo
-  attr_accessor :destinationZoneName
-  attr_accessor :carrierCode
-  attr_accessor :classCode
-  attr_accessor :firstItemRate
-  attr_accessor :additionalItemRate
-  attr_accessor :firstItemHandlingRate
-  attr_accessor :additionalItemHandlingRate
-  attr_accessor :freeShippingIfBuyItNow
-  attr_accessor :firstItemRateAttribute
-  attr_accessor :firstItemHandlingRateAttribute
-  attr_accessor :additionalItemRateAttribute
-  attr_accessor :additionalItemHandlingRateAttribute
-
-  def initialize(destinationZoneName = nil, carrierCode = nil, classCode = nil, firstItemRate = nil, additionalItemRate = nil, firstItemHandlingRate = nil, additionalItemHandlingRate = nil, freeShippingIfBuyItNow = nil, firstItemRateAttribute = nil, firstItemHandlingRateAttribute = nil, additionalItemRateAttribute = nil, additionalItemHandlingRateAttribute = nil)
-    @destinationZoneName = destinationZoneName
-    @carrierCode = carrierCode
-    @classCode = classCode
-    @firstItemRate = firstItemRate
-    @additionalItemRate = additionalItemRate
-    @firstItemHandlingRate = firstItemHandlingRate
-    @additionalItemHandlingRate = additionalItemHandlingRate
-    @freeShippingIfBuyItNow = freeShippingIfBuyItNow
-    @firstItemRateAttribute = firstItemRateAttribute
-    @firstItemHandlingRateAttribute = firstItemHandlingRateAttribute
-    @additionalItemRateAttribute = additionalItemRateAttribute
-    @additionalItemHandlingRateAttribute = additionalItemHandlingRateAttribute
-  end
-end
-
 # {http://api.channeladvisor.com/webservices/}InventoryItemCriteria
-#   dateRangeField - ChannelAdvisor::InventoryServiceSOAP::InventoryItemDateRangeField
+#   dateRangeField - SOAP::SOAPString
 #   dateRangeStartGMT - SOAP::SOAPDateTime
 #   dateRangeEndGMT - SOAP::SOAPDateTime
 #   partialSku - SOAP::SOAPString
@@ -466,8 +485,8 @@ end
 #   skuEndsWith - SOAP::SOAPString
 #   classificationName - SOAP::SOAPString
 #   labelName - SOAP::SOAPString
-#   quantityCheckField - ChannelAdvisor::InventoryServiceSOAP::InventoryItemQuantityField
-#   quantityCheckType - ChannelAdvisor::InventoryServiceSOAP::NumericFilterType
+#   quantityCheckField - SOAP::SOAPString
+#   quantityCheckType - SOAP::SOAPString
 #   quantityCheckValue - SOAP::SOAPInt
 #   pageNumber - SOAP::SOAPInt
 #   pageSize - SOAP::SOAPInt
@@ -541,13 +560,13 @@ class APIResultOfArrayOfString
   end
 end
 
-# {http://api.channeladvisor.com/webservices/}APIResultOfArrayOfShippingRateInfo
+# {http://api.channeladvisor.com/webservices/}APIResultOfArrayOfDistributionCenterInfoResponse
 #   status - ChannelAdvisor::InventoryServiceSOAP::ResultStatus
 #   messageCode - SOAP::SOAPInt
 #   message - SOAP::SOAPString
 #   data - SOAP::SOAPString
-#   resultData - ChannelAdvisor::InventoryServiceSOAP::ArrayOfShippingRateInfo
-class APIResultOfArrayOfShippingRateInfo
+#   resultData - ChannelAdvisor::InventoryServiceSOAP::ArrayOfDistributionCenterInfoResponse
+class APIResultOfArrayOfDistributionCenterInfoResponse
   attr_accessor :status
   attr_accessor :messageCode
   attr_accessor :message
@@ -783,7 +802,7 @@ end
 # {http://api.channeladvisor.com/webservices/}InventoryQuantityResponse
 #   sKU - SOAP::SOAPString
 #   quantity - SOAP::SOAPInt
-#   messageCode - ChannelAdvisor::InventoryServiceSOAP::ErrorCode
+#   messageCode - SOAP::SOAPInt
 #   message - SOAP::SOAPString
 class InventoryQuantityResponse
   attr_accessor :sKU
@@ -799,20 +818,102 @@ class InventoryQuantityResponse
   end
 end
 
+# {http://api.channeladvisor.com/webservices/}APIResultOfArrayOfDistributionCenterResponse
+#   status - ChannelAdvisor::InventoryServiceSOAP::ResultStatus
+#   messageCode - SOAP::SOAPInt
+#   message - SOAP::SOAPString
+#   data - SOAP::SOAPString
+#   resultData - ChannelAdvisor::InventoryServiceSOAP::ArrayOfDistributionCenterResponse
+class APIResultOfArrayOfDistributionCenterResponse
+  attr_accessor :status
+  attr_accessor :messageCode
+  attr_accessor :message
+  attr_accessor :data
+  attr_accessor :resultData
+
+  def initialize(status = nil, messageCode = nil, message = nil, data = nil, resultData = nil)
+    @status = status
+    @messageCode = messageCode
+    @message = message
+    @data = data
+    @resultData = resultData
+  end
+end
+
+# {http://api.channeladvisor.com/webservices/}ArrayOfDistributionCenterResponse
+class ArrayOfDistributionCenterResponse < ::Array
+end
+
+# {http://api.channeladvisor.com/webservices/}DistributionCenterResponse
+#   distributionCenterCode - SOAP::SOAPString
+#   distributionCenterName - SOAP::SOAPString
+#   distributionCenterType - SOAP::SOAPString
+#   contactName - SOAP::SOAPString
+#   contactEmail - SOAP::SOAPString
+#   contactPhone - SOAP::SOAPString
+#   address1 - SOAP::SOAPString
+#   address2 - SOAP::SOAPString
+#   city - SOAP::SOAPString
+#   regionName - SOAP::SOAPString
+#   countryName - SOAP::SOAPString
+#   postalCode - SOAP::SOAPString
+#   isDefault - SOAP::SOAPBoolean
+#   isExternallyManaged - SOAP::SOAPBoolean
+#   isPickupLocation - SOAP::SOAPBoolean
+#   isShipLocation - SOAP::SOAPBoolean
+class DistributionCenterResponse
+  attr_accessor :distributionCenterCode
+  attr_accessor :distributionCenterName
+  attr_accessor :distributionCenterType
+  attr_accessor :contactName
+  attr_accessor :contactEmail
+  attr_accessor :contactPhone
+  attr_accessor :address1
+  attr_accessor :address2
+  attr_accessor :city
+  attr_accessor :regionName
+  attr_accessor :countryName
+  attr_accessor :postalCode
+  attr_accessor :isDefault
+  attr_accessor :isExternallyManaged
+  attr_accessor :isPickupLocation
+  attr_accessor :isShipLocation
+
+  def initialize(distributionCenterCode = nil, distributionCenterName = nil, distributionCenterType = nil, contactName = nil, contactEmail = nil, contactPhone = nil, address1 = nil, address2 = nil, city = nil, regionName = nil, countryName = nil, postalCode = nil, isDefault = nil, isExternallyManaged = nil, isPickupLocation = nil, isShipLocation = nil)
+    @distributionCenterCode = distributionCenterCode
+    @distributionCenterName = distributionCenterName
+    @distributionCenterType = distributionCenterType
+    @contactName = contactName
+    @contactEmail = contactEmail
+    @contactPhone = contactPhone
+    @address1 = address1
+    @address2 = address2
+    @city = city
+    @regionName = regionName
+    @countryName = countryName
+    @postalCode = postalCode
+    @isDefault = isDefault
+    @isExternallyManaged = isExternallyManaged
+    @isPickupLocation = isPickupLocation
+    @isShipLocation = isShipLocation
+  end
+end
+
 # {http://api.channeladvisor.com/webservices/}InventoryItemSubmit
 #   sku - SOAP::SOAPString
 #   title - SOAP::SOAPString
 #   subtitle - SOAP::SOAPString
 #   shortDescription - SOAP::SOAPString
 #   description - SOAP::SOAPString
-#   weight - SOAP::SOAPDouble
+#   weight - SOAP::SOAPDecimal
 #   supplierCode - SOAP::SOAPString
 #   warehouseLocation - SOAP::SOAPString
 #   taxProductCode - SOAP::SOAPString
-#   flagStyle - ChannelAdvisor::InventoryServiceSOAP::FlagType
+#   flagStyle - SOAP::SOAPString
 #   flagDescription - SOAP::SOAPString
 #   isBlocked - SOAP::SOAPBoolean
 #   blockComment - SOAP::SOAPString
+#   blockExternalQuantity - SOAP::SOAPBoolean
 #   aSIN - SOAP::SOAPString
 #   iSBN - SOAP::SOAPString
 #   uPC - SOAP::SOAPString
@@ -824,19 +925,18 @@ end
 #   warranty - SOAP::SOAPString
 #   productMargin - SOAP::SOAPDecimal
 #   supplierPO - SOAP::SOAPString
-#   receivedInInventory - SOAP::SOAPDateTime
 #   harmonizedCode - SOAP::SOAPString
 #   height - SOAP::SOAPDecimal
 #   length - SOAP::SOAPDecimal
 #   width - SOAP::SOAPDecimal
 #   classification - SOAP::SOAPString
-#   quantityInfo - ChannelAdvisor::InventoryServiceSOAP::QuantityInfoSubmit
+#   dCQuantityUpdateType - SOAP::SOAPString
+#   distributionCenterList - ChannelAdvisor::InventoryServiceSOAP::ArrayOfDistributionCenterInfoSubmit
 #   priceInfo - ChannelAdvisor::InventoryServiceSOAP::PriceInfo
 #   attributeList - ChannelAdvisor::InventoryServiceSOAP::ArrayOfAttributeInfo
 #   variationInfo - ChannelAdvisor::InventoryServiceSOAP::VariationInfo
 #   storeInfo - ChannelAdvisor::InventoryServiceSOAP::StoreInfo
 #   imageList - ChannelAdvisor::InventoryServiceSOAP::ArrayOfImageInfoSubmit
-#   shippingInfo - ChannelAdvisor::InventoryServiceSOAP::ShippingInfo
 #   labelList - ChannelAdvisor::InventoryServiceSOAP::ArrayOfString
 #   metaDescription - SOAP::SOAPString
 class InventoryItemSubmit
@@ -853,6 +953,7 @@ class InventoryItemSubmit
   attr_accessor :flagDescription
   attr_accessor :isBlocked
   attr_accessor :blockComment
+  attr_accessor :blockExternalQuantity
   attr_accessor :aSIN
   attr_accessor :iSBN
   attr_accessor :uPC
@@ -864,23 +965,22 @@ class InventoryItemSubmit
   attr_accessor :warranty
   attr_accessor :productMargin
   attr_accessor :supplierPO
-  attr_accessor :receivedInInventory
   attr_accessor :harmonizedCode
   attr_accessor :height
   attr_accessor :length
   attr_accessor :width
   attr_accessor :classification
-  attr_accessor :quantityInfo
+  attr_accessor :dCQuantityUpdateType
+  attr_accessor :distributionCenterList
   attr_accessor :priceInfo
   attr_accessor :attributeList
   attr_accessor :variationInfo
   attr_accessor :storeInfo
   attr_accessor :imageList
-  attr_accessor :shippingInfo
   attr_accessor :labelList
   attr_accessor :metaDescription
 
-  def initialize(sku = nil, title = nil, subtitle = nil, shortDescription = nil, description = nil, weight = nil, supplierCode = nil, warehouseLocation = nil, taxProductCode = nil, flagStyle = nil, flagDescription = nil, isBlocked = nil, blockComment = nil, aSIN = nil, iSBN = nil, uPC = nil, mPN = nil, eAN = nil, manufacturer = nil, brand = nil, condition = nil, warranty = nil, productMargin = nil, supplierPO = nil, receivedInInventory = nil, harmonizedCode = nil, height = nil, length = nil, width = nil, classification = nil, quantityInfo = nil, priceInfo = nil, attributeList = nil, variationInfo = nil, storeInfo = nil, imageList = nil, shippingInfo = nil, labelList = nil, metaDescription = nil)
+  def initialize(sku = nil, title = nil, subtitle = nil, shortDescription = nil, description = nil, weight = nil, supplierCode = nil, warehouseLocation = nil, taxProductCode = nil, flagStyle = nil, flagDescription = nil, isBlocked = nil, blockComment = nil, blockExternalQuantity = nil, aSIN = nil, iSBN = nil, uPC = nil, mPN = nil, eAN = nil, manufacturer = nil, brand = nil, condition = nil, warranty = nil, productMargin = nil, supplierPO = nil, harmonizedCode = nil, height = nil, length = nil, width = nil, classification = nil, dCQuantityUpdateType = nil, distributionCenterList = nil, priceInfo = nil, attributeList = nil, variationInfo = nil, storeInfo = nil, imageList = nil, labelList = nil, metaDescription = nil)
     @sku = sku
     @title = title
     @subtitle = subtitle
@@ -894,6 +994,7 @@ class InventoryItemSubmit
     @flagDescription = flagDescription
     @isBlocked = isBlocked
     @blockComment = blockComment
+    @blockExternalQuantity = blockExternalQuantity
     @aSIN = aSIN
     @iSBN = iSBN
     @uPC = uPC
@@ -905,34 +1006,49 @@ class InventoryItemSubmit
     @warranty = warranty
     @productMargin = productMargin
     @supplierPO = supplierPO
-    @receivedInInventory = receivedInInventory
     @harmonizedCode = harmonizedCode
     @height = height
     @length = length
     @width = width
     @classification = classification
-    @quantityInfo = quantityInfo
+    @dCQuantityUpdateType = dCQuantityUpdateType
+    @distributionCenterList = distributionCenterList
     @priceInfo = priceInfo
     @attributeList = attributeList
     @variationInfo = variationInfo
     @storeInfo = storeInfo
     @imageList = imageList
-    @shippingInfo = shippingInfo
     @labelList = labelList
     @metaDescription = metaDescription
   end
 end
 
-# {http://api.channeladvisor.com/webservices/}QuantityInfoSubmit
-#   updateType - ChannelAdvisor::InventoryServiceSOAP::InventoryQuantityUpdateType
-#   total - SOAP::SOAPInt
-class QuantityInfoSubmit
-  attr_accessor :updateType
-  attr_accessor :total
+# {http://api.channeladvisor.com/webservices/}ArrayOfDistributionCenterInfoSubmit
+class ArrayOfDistributionCenterInfoSubmit < ::Array
+end
 
-  def initialize(updateType = nil, total = nil)
-    @updateType = updateType
-    @total = total
+# {http://api.channeladvisor.com/webservices/}DistributionCenterInfoSubmit
+#   distributionCenterCode - SOAP::SOAPString
+#   quantity - SOAP::SOAPInt
+#   quantityUpdateType - SOAP::SOAPString
+#   warehouseLocation - SOAP::SOAPString
+#   receivedInInventory - SOAP::SOAPDateTime
+#   shippingRateList - ChannelAdvisor::InventoryServiceSOAP::ArrayOfShippingRateInfo
+class DistributionCenterInfoSubmit
+  attr_accessor :distributionCenterCode
+  attr_accessor :quantity
+  attr_accessor :quantityUpdateType
+  attr_accessor :warehouseLocation
+  attr_accessor :receivedInInventory
+  attr_accessor :shippingRateList
+
+  def initialize(distributionCenterCode = nil, quantity = nil, quantityUpdateType = nil, warehouseLocation = nil, receivedInInventory = nil, shippingRateList = nil)
+    @distributionCenterCode = distributionCenterCode
+    @quantity = quantity
+    @quantityUpdateType = quantityUpdateType
+    @warehouseLocation = warehouseLocation
+    @receivedInInventory = receivedInInventory
+    @shippingRateList = shippingRateList
   end
 end
 
@@ -1004,16 +1120,22 @@ end
 
 # {http://api.channeladvisor.com/webservices/}InventoryItemQuantityAndPrice
 #   sku - SOAP::SOAPString
-#   quantityInfo - ChannelAdvisor::InventoryServiceSOAP::QuantityInfoSubmit
+#   distributionCenterCode - SOAP::SOAPString
+#   quantity - SOAP::SOAPInt
+#   updateType - SOAP::SOAPString
 #   priceInfo - ChannelAdvisor::InventoryServiceSOAP::PriceInfo
 class InventoryItemQuantityAndPrice
   attr_accessor :sku
-  attr_accessor :quantityInfo
+  attr_accessor :distributionCenterCode
+  attr_accessor :quantity
+  attr_accessor :updateType
   attr_accessor :priceInfo
 
-  def initialize(sku = nil, quantityInfo = nil, priceInfo = nil)
+  def initialize(sku = nil, distributionCenterCode = nil, quantity = nil, updateType = nil, priceInfo = nil)
     @sku = sku
-    @quantityInfo = quantityInfo
+    @distributionCenterCode = distributionCenterCode
+    @quantity = quantity
+    @updateType = updateType
     @priceInfo = priceInfo
   end
 end
@@ -1220,165 +1342,6 @@ class ResultStatus < ::String
   Success = new("Success")
 end
 
-# {http://api.channeladvisor.com/webservices/}FlagType
-class FlagType < ::String
-  BlueFlag = new("BlueFlag")
-  ExclamationPoint = new("ExclamationPoint")
-  GreenFlag = new("GreenFlag")
-  ItemCopied = new("ItemCopied")
-  NoFlag = new("NoFlag")
-  NotAvailable = new("NotAvailable")
-  Price = new("Price")
-  QuestionMark = new("QuestionMark")
-  RedFlag = new("RedFlag")
-  YellowFlag = new("YellowFlag")
-end
-
-# {http://api.channeladvisor.com/webservices/}ShippingRateAttribute
-class ShippingRateAttribute < ::String
-  NotAvailable = new("NotAvailable")
-  Price = new("Price")
-  TBD = new("TBD")
-end
-
-# {http://api.channeladvisor.com/webservices/}HandlingRateAttribute
-class HandlingRateAttribute < ::String
-  NotAvailable = new("NotAvailable")
-  Price = new("Price")
-end
-
-# {http://api.channeladvisor.com/webservices/}InventoryItemDateRangeField
-class InventoryItemDateRangeField < ::String
-  CreateDate = new("CreateDate")
-  LastUpdateDate = new("LastUpdateDate")
-  QtyLastModifiedDate = new("QtyLastModifiedDate")
-end
-
-# {http://api.channeladvisor.com/webservices/}InventoryItemQuantityField
-class InventoryItemQuantityField < ::String
-  Available = new("Available")
-  Open = new("Open")
-  PendingCheckout = new("PendingCheckout")
-  PendingPayment = new("PendingPayment")
-  PendingShipment = new("PendingShipment")
-  Total = new("Total")
-end
-
-# {http://api.channeladvisor.com/webservices/}NumericFilterType
-class NumericFilterType < ::String
-  EqualTo = new("EqualTo")
-  GreaterThan = new("GreaterThan")
-  GreaterThanOrEqualTo = new("GreaterThanOrEqualTo")
-  LessThan = new("LessThan")
-  LessThanOrEqualTo = new("LessThanOrEqualTo")
-end
-
-# {http://api.channeladvisor.com/webservices/}InventoryItemSortField
-class InventoryItemSortField < ::String
-  Sku = new("Sku")
-  Title = new("Title")
-end
-
-# {http://api.channeladvisor.com/webservices/}SortDirection
-class SortDirection < ::String
-  Ascending = new("Ascending")
-  Descending = new("Descending")
-end
-
-# {http://api.channeladvisor.com/webservices/}ErrorCode
-class ErrorCode < ::String
-  AccountIDIsBlank = new("AccountIDIsBlank")
-  AccountIDIsNull = new("AccountIDIsNull")
-  AccountIDNotExists = new("AccountIDNotExists")
-  CartIDNull = new("CartIDNull")
-  CartNotFound = new("CartNotFound")
-  DataIntegrityViolation = new("DataIntegrityViolation")
-  EMailAddressBadFormat = new("EMailAddressBadFormat")
-  EmptyCartSubmit = new("EmptyCartSubmit")
-  ErrorInvoiceCreation = new("ErrorInvoiceCreation")
-  Error_AuctionWinnerValidation = new("Error_AuctionWinnerValidation")
-  Error_NotValidCartID = new("Error_NotValidCartID")
-  Error_ProcessingASale = new("Error_ProcessingASale")
-  Error_PromotionNotFound = new("Error_PromotionNotFound")
-  Error_SKUDuplicated = new("Error_SKUDuplicated")
-  Error_SavingBillingData = new("Error_SavingBillingData")
-  Error_SavingOrderShippingData = new("Error_SavingOrderShippingData")
-  Error_SavingTaxInformation = new("Error_SavingTaxInformation")
-  FetchFilterInfoNull = new("FetchFilterInfoNull")
-  InvalidArguments = new("InvalidArguments")
-  InvalidCartID = new("InvalidCartID")
-  InvalidSaleSource = new("InvalidSaleSource")
-  Invalid_AddressLength = new("Invalid_AddressLength")
-  Invalid_BlockedSku = new("Invalid_BlockedSku")
-  Invalid_BundleSKU = new("Invalid_BundleSKU")
-  Invalid_CCLast4 = new("Invalid_CCLast4")
-  Invalid_CarrierClassData = new("Invalid_CarrierClassData")
-  Invalid_CityLength = new("Invalid_CityLength")
-  Invalid_CompanyNameLength = new("Invalid_CompanyNameLength")
-  Invalid_CountryLength = new("Invalid_CountryLength")
-  Invalid_CustomFieldValue = new("Invalid_CustomFieldValue")
-  Invalid_FirstNameLength = new("Invalid_FirstNameLength")
-  Invalid_JobTitleLength = new("Invalid_JobTitleLength")
-  Invalid_LastNameLength = new("Invalid_LastNameLength")
-  Invalid_OrderId = new("Invalid_OrderId")
-  Invalid_OrderNumberLength = new("Invalid_OrderNumberLength")
-  Invalid_OrderStatus = new("Invalid_OrderStatus")
-  Invalid_PhoneLength = new("Invalid_PhoneLength")
-  Invalid_PostalCodeLength = new("Invalid_PostalCodeLength")
-  Invalid_ShippingInstructionsLgth = new("Invalid_ShippingInstructionsLgth")
-  Invalid_SuffixLength = new("Invalid_SuffixLength")
-  Invalid_TitleLength = new("Invalid_TitleLength")
-  Invalid_TrackingNumberLgth = new("Invalid_TrackingNumberLgth")
-  Invalid_WithdrawReason = new("Invalid_WithdrawReason")
-  LineItemIDNotFound = new("LineItemIDNotFound")
-  LineItemOrSKUEmpty = new("LineItemOrSKUEmpty")
-  MergeInvoice_CheckoutNotOpen = new("MergeInvoice_CheckoutNotOpen")
-  MergeInvoice_DiffTaxModule = new("MergeInvoice_DiffTaxModule")
-  MergeInvoice_Error = new("MergeInvoice_Error")
-  MergeInvoice_SameInvoice = new("MergeInvoice_SameInvoice")
-  MissingEmailAddress = new("MissingEmailAddress")
-  MultiplePromoCodesSpecified = new("MultiplePromoCodesSpecified")
-  NegativeQuantity = new("NegativeQuantity")
-  NotMultiSellerDCCompatible = new("NotMultiSellerDCCompatible")
-  OrderCollectionNull = new("OrderCollectionNull")
-  OrderIdIsNullOrEmpty = new("OrderIdIsNullOrEmpty")
-  PromoAmountOutOfRange = new("PromoAmountOutOfRange")
-  QuantityNotEnough = new("QuantityNotEnough")
-  RoverRegionNotFound = new("RoverRegionNotFound")
-  SKUNotFound = new("SKUNotFound")
-  ShippingCostNegative = new("ShippingCostNegative")
-  SkuIsBlank = new("SkuIsBlank")
-  SkuIsNull = new("SkuIsNull")
-  SplitInvoice_CheckoutNotOpen = new("SplitInvoice_CheckoutNotOpen")
-  SplitInvoice_Error = new("SplitInvoice_Error")
-  SplitInvoice_NoLineItems = new("SplitInvoice_NoLineItems")
-  SplitInvoice_NotEnoughLineItems = new("SplitInvoice_NotEnoughLineItems")
-  Success = new("Success")
-  TooManyGiftWrapAmounts = new("TooManyGiftWrapAmounts")
-  TooManyInsuranceAmounts = new("TooManyInsuranceAmounts")
-  TooManyRecyclingFeeAmounts = new("TooManyRecyclingFeeAmounts")
-  TooManySKUsRequested = new("TooManySKUsRequested")
-  TooManyShippingAmounts = new("TooManyShippingAmounts")
-  TooManyTaxAmounts = new("TooManyTaxAmounts")
-  TooManyVATGiftWrapAmounts = new("TooManyVATGiftWrapAmounts")
-  TooManyVATShippingAmounts = new("TooManyVATShippingAmounts")
-  Unexpected = new("Unexpected")
-  VATRangeOutOfRange = new("VATRangeOutOfRange")
-  WrongAccountSettings = new("WrongAccountSettings")
-  WrongCountryInfo = new("WrongCountryInfo")
-  WrongStateInfo = new("WrongStateInfo")
-  ZeroQuantity = new("ZeroQuantity")
-end
-
-# {http://api.channeladvisor.com/webservices/}InventoryQuantityUpdateType
-class InventoryQuantityUpdateType < ::String
-  Absolute = new("Absolute")
-  Available = new("Available")
-  InStock = new("InStock")
-  Relative = new("Relative")
-  UnShipped = new("UnShipped")
-end
-
 # {http://api.channeladvisor.com/webservices/}DoesSkuExist
 #   accountID - SOAP::SOAPString
 #   sku - SOAP::SOAPString
@@ -1465,8 +1428,8 @@ end
 #   accountID - SOAP::SOAPString
 #   itemCriteria - ChannelAdvisor::InventoryServiceSOAP::InventoryItemCriteria
 #   detailLevel - ChannelAdvisor::InventoryServiceSOAP::InventoryItemDetailLevel
-#   sortField - ChannelAdvisor::InventoryServiceSOAP::InventoryItemSortField
-#   sortDirection - ChannelAdvisor::InventoryServiceSOAP::SortDirection
+#   sortField - SOAP::SOAPString
+#   sortDirection - SOAP::SOAPString
 class GetFilteredInventoryItemList
   attr_accessor :accountID
   attr_accessor :itemCriteria
@@ -1496,8 +1459,8 @@ end
 # {http://api.channeladvisor.com/webservices/}GetFilteredSkuList
 #   accountID - SOAP::SOAPString
 #   itemCriteria - ChannelAdvisor::InventoryServiceSOAP::InventoryItemCriteria
-#   sortField - ChannelAdvisor::InventoryServiceSOAP::InventoryItemSortField
-#   sortDirection - ChannelAdvisor::InventoryServiceSOAP::SortDirection
+#   sortField - SOAP::SOAPString
+#   sortDirection - SOAP::SOAPString
 class GetFilteredSkuList
   attr_accessor :accountID
   attr_accessor :itemCriteria
@@ -1536,7 +1499,7 @@ class GetInventoryItemShippingInfo
 end
 
 # {http://api.channeladvisor.com/webservices/}GetInventoryItemShippingInfoResponse
-#   getInventoryItemShippingInfoResult - ChannelAdvisor::InventoryServiceSOAP::APIResultOfArrayOfShippingRateInfo
+#   getInventoryItemShippingInfoResult - ChannelAdvisor::InventoryServiceSOAP::APIResultOfArrayOfDistributionCenterInfoResponse
 class GetInventoryItemShippingInfoResponse
   attr_accessor :getInventoryItemShippingInfoResult
 
@@ -1723,6 +1686,26 @@ class GetInventoryQuantityListResponse
 
   def initialize(getInventoryQuantityListResult = nil)
     @getInventoryQuantityListResult = getInventoryQuantityListResult
+  end
+end
+
+# {http://api.channeladvisor.com/webservices/}GetDistributionCenterList
+#   accountID - SOAP::SOAPString
+class GetDistributionCenterList
+  attr_accessor :accountID
+
+  def initialize(accountID = nil)
+    @accountID = accountID
+  end
+end
+
+# {http://api.channeladvisor.com/webservices/}GetDistributionCenterListResponse
+#   getDistributionCenterListResult - ChannelAdvisor::InventoryServiceSOAP::APIResultOfArrayOfDistributionCenterResponse
+class GetDistributionCenterListResponse
+  attr_accessor :getDistributionCenterListResult
+
+  def initialize(getDistributionCenterListResult = nil)
+    @getDistributionCenterListResult = getDistributionCenterListResult
   end
 end
 

--- a/lib/channel_advisor/listing_service/client.rb
+++ b/lib/channel_advisor/listing_service/client.rb
@@ -6,7 +6,7 @@ module ChannelAdvisor
 module ListingServiceSOAP
 
 class ListingServiceSoap < ::SOAP::RPC::Driver
-  DefaultEndpointUrl = "https://api.channeladvisor.com/ChannelAdvisorAPI/v4/ListingService.asmx"
+  DefaultEndpointUrl = "https://api.channeladvisor.com/ChannelAdvisorAPI/v7/ListingService.asmx"
 
   Methods = [
     [ "http://api.channeladvisor.com/webservices/WithdrawListings",

--- a/lib/channel_advisor/listing_service/mapping_registry.rb
+++ b/lib/channel_advisor/listing_service/mapping_registry.rb
@@ -50,11 +50,6 @@ module DefaultMappingRegistry
   )
 
   EncodedRegistry.register(
-    :class => ChannelAdvisor::ListingServiceSOAP::WithdrawReason,
-    :schema_type => XSD::QName.new(NsWebservices, "WithdrawReason")
-  )
-
-  EncodedRegistry.register(
     :class => ChannelAdvisor::ListingServiceSOAP::ResultStatus,
     :schema_type => XSD::QName.new(NsWebservices, "ResultStatus")
   )
@@ -101,11 +96,6 @@ module DefaultMappingRegistry
   )
 
   LiteralRegistry.register(
-    :class => ChannelAdvisor::ListingServiceSOAP::WithdrawReason,
-    :schema_type => XSD::QName.new(NsWebservices, "WithdrawReason")
-  )
-
-  LiteralRegistry.register(
     :class => ChannelAdvisor::ListingServiceSOAP::ResultStatus,
     :schema_type => XSD::QName.new(NsWebservices, "ResultStatus")
   )
@@ -114,10 +104,10 @@ module DefaultMappingRegistry
     :class => ChannelAdvisor::ListingServiceSOAP::WithdrawListings,
     :schema_name => XSD::QName.new(NsWebservices, "WithdrawListings"),
     :schema_element => [
-      ["accountID", "SOAP::SOAPString", [0, 1]],
+      ["accountID", "SOAP::SOAPString"],
       ["skuList", "ChannelAdvisor::ListingServiceSOAP::ArrayOfString", [0, 1]],
       ["listingIDList", "ChannelAdvisor::ListingServiceSOAP::ArrayOfString", [0, 1]],
-      ["withdrawReason", "ChannelAdvisor::ListingServiceSOAP::WithdrawReason"]
+      ["withdrawReason", "SOAP::SOAPString", [0, 1]]
     ]
   )
 

--- a/lib/channel_advisor/listing_service/types.rb
+++ b/lib/channel_advisor/listing_service/types.rb
@@ -64,14 +64,6 @@ class APIResultOfString
   end
 end
 
-# {http://api.channeladvisor.com/webservices/}WithdrawReason
-class WithdrawReason < ::String
-  ErrorInMinimumBidOrReserve = new("ErrorInMinimumBidOrReserve")
-  ErrorInTheListing = new("ErrorInTheListing")
-  ItemNoLongerAvailableForSale = new("ItemNoLongerAvailableForSale")
-  ItemWasLostOrBroken = new("ItemWasLostOrBroken")
-end
-
 # {http://api.channeladvisor.com/webservices/}ResultStatus
 class ResultStatus < ::String
   Failure = new("Failure")
@@ -82,7 +74,7 @@ end
 #   accountID - SOAP::SOAPString
 #   skuList - ChannelAdvisor::ListingServiceSOAP::ArrayOfString
 #   listingIDList - ChannelAdvisor::ListingServiceSOAP::ArrayOfString
-#   withdrawReason - ChannelAdvisor::ListingServiceSOAP::WithdrawReason
+#   withdrawReason - SOAP::SOAPString
 class WithdrawListings
   attr_accessor :accountID
   attr_accessor :skuList

--- a/lib/channel_advisor/marketplace_ad_service/client.rb
+++ b/lib/channel_advisor/marketplace_ad_service/client.rb
@@ -6,7 +6,7 @@ module ChannelAdvisor
 module MarketplaceAdServiceSOAP
 
 class MarketplaceAdServiceSoap < ::SOAP::RPC::Driver
-  DefaultEndpointUrl = "https://api.channeladvisor.com/ChannelAdvisorAPI/v4/MarketplaceAdService.asmx"
+  DefaultEndpointUrl = "https://api.channeladvisor.com/ChannelAdvisorAPI/v7/MarketplaceAdService.asmx"
 
   Methods = [
     [ "http://api.channeladvisor.com/webservices/AddMarketplaceAd",
@@ -29,6 +29,14 @@ class MarketplaceAdServiceSoap < ::SOAP::RPC::Driver
       "deleteMarketplaceAd",
       [ [:in, "parameters", ["::SOAP::SOAPElement", "http://api.channeladvisor.com/webservices/", "DeleteMarketplaceAd"]],
         [:out, "parameters", ["::SOAP::SOAPElement", "http://api.channeladvisor.com/webservices/", "DeleteMarketplaceAdResponse"]] ],
+      { :request_style =>  :document, :request_use =>  :literal,
+        :response_style => :document, :response_use => :literal,
+        :faults => {} }
+    ],
+    [ "http://api.channeladvisor.com/webservices/DeleteMarketplaceAdList",
+      "deleteMarketplaceAdList",
+      [ [:in, "parameters", ["::SOAP::SOAPElement", "http://api.channeladvisor.com/webservices/", "DeleteMarketplaceAdList"]],
+        [:out, "parameters", ["::SOAP::SOAPElement", "http://api.channeladvisor.com/webservices/", "DeleteMarketplaceAdListResponse"]] ],
       { :request_style =>  :document, :request_use =>  :literal,
         :response_style => :document, :response_use => :literal,
         :faults => {} }

--- a/lib/channel_advisor/marketplace_ad_service/mapping_registry.rb
+++ b/lib/channel_advisor/marketplace_ad_service/mapping_registry.rb
@@ -18,7 +18,7 @@ module DefaultMappingRegistry
       ["postingTemplate", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "PostingTemplate")], [0, 1]],
       ["adTemplate", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "AdTemplate")], [0, 1]],
       ["schedule", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Schedule")], [0, 1]],
-      ["flagStyle", ["ChannelAdvisor::MarketplaceAdServiceSOAP::FlagType", XSD::QName.new(NsWebservices, "FlagStyle")]],
+      ["flagStyle", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "FlagStyle")], [0, 1]],
       ["flagDescription", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "FlagDescription")], [0, 1]],
       ["primaryCategory", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "PrimaryCategory")], [0, 1]],
       ["secondaryCategory", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "SecondaryCategory")], [0, 1]],
@@ -108,6 +108,14 @@ module DefaultMappingRegistry
   )
 
   EncodedRegistry.register(
+    :class => ChannelAdvisor::MarketplaceAdServiceSOAP::ArrayOfInt,
+    :schema_type => XSD::QName.new(NsWebservices, "ArrayOfInt"),
+    :schema_element => [
+      ["int", "SOAP::SOAPInt[]", [0, nil]]
+    ]
+  )
+
+  EncodedRegistry.register(
     :class => ChannelAdvisor::MarketplaceAdServiceSOAP::APIResultOfString,
     :schema_type => XSD::QName.new(NsWebservices, "APIResultOfString"),
     :schema_element => [
@@ -117,11 +125,6 @@ module DefaultMappingRegistry
       ["data", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Data")], [0, 1]],
       ["resultData", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "ResultData")], [0, 1]]
     ]
-  )
-
-  EncodedRegistry.register(
-    :class => ChannelAdvisor::MarketplaceAdServiceSOAP::FlagType,
-    :schema_type => XSD::QName.new(NsWebservices, "FlagType")
   )
 
   EncodedRegistry.register(
@@ -139,7 +142,7 @@ module DefaultMappingRegistry
       ["postingTemplate", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "PostingTemplate")], [0, 1]],
       ["adTemplate", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "AdTemplate")], [0, 1]],
       ["schedule", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Schedule")], [0, 1]],
-      ["flagStyle", ["ChannelAdvisor::MarketplaceAdServiceSOAP::FlagType", XSD::QName.new(NsWebservices, "FlagStyle")]],
+      ["flagStyle", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "FlagStyle")], [0, 1]],
       ["flagDescription", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "FlagDescription")], [0, 1]],
       ["primaryCategory", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "PrimaryCategory")], [0, 1]],
       ["secondaryCategory", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "SecondaryCategory")], [0, 1]],
@@ -229,6 +232,14 @@ module DefaultMappingRegistry
   )
 
   LiteralRegistry.register(
+    :class => ChannelAdvisor::MarketplaceAdServiceSOAP::ArrayOfInt,
+    :schema_type => XSD::QName.new(NsWebservices, "ArrayOfInt"),
+    :schema_element => [
+      ["int", "SOAP::SOAPInt[]", [0, nil]]
+    ]
+  )
+
+  LiteralRegistry.register(
     :class => ChannelAdvisor::MarketplaceAdServiceSOAP::APIResultOfString,
     :schema_type => XSD::QName.new(NsWebservices, "APIResultOfString"),
     :schema_element => [
@@ -238,11 +249,6 @@ module DefaultMappingRegistry
       ["data", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Data")], [0, 1]],
       ["resultData", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "ResultData")], [0, 1]]
     ]
-  )
-
-  LiteralRegistry.register(
-    :class => ChannelAdvisor::MarketplaceAdServiceSOAP::FlagType,
-    :schema_type => XSD::QName.new(NsWebservices, "FlagType")
   )
 
   LiteralRegistry.register(
@@ -282,10 +288,10 @@ module DefaultMappingRegistry
     :schema_element => [
       ["accountID", "SOAP::SOAPString"],
       ["skuList", "ChannelAdvisor::MarketplaceAdServiceSOAP::ArrayOfMarketplaceAdSkuRequest", [0, 1]],
-      ["postingTemplate", "SOAP::SOAPString", [0, 1]],
+      ["postingTemplate", "SOAP::SOAPString"],
       ["adTemplate", "SOAP::SOAPString", [0, 1]],
       ["schedule", "SOAP::SOAPString", [0, 1]],
-      ["flagStyle", "ChannelAdvisor::MarketplaceAdServiceSOAP::FlagType"],
+      ["flagStyle", "SOAP::SOAPString", [0, 1]],
       ["flagDescription", "SOAP::SOAPString", [0, 1]],
       ["primaryCategory", "SOAP::SOAPString", [0, 1]],
       ["secondaryCategory", "SOAP::SOAPString", [0, 1]],
@@ -316,6 +322,23 @@ module DefaultMappingRegistry
     :schema_name => XSD::QName.new(NsWebservices, "DeleteMarketplaceAdResponse"),
     :schema_element => [
       ["deleteMarketplaceAdResult", ["ChannelAdvisor::MarketplaceAdServiceSOAP::APIResultOfBoolean", XSD::QName.new(NsWebservices, "DeleteMarketplaceAdResult")], [0, 1]]
+    ]
+  )
+
+  LiteralRegistry.register(
+    :class => ChannelAdvisor::MarketplaceAdServiceSOAP::DeleteMarketplaceAdList,
+    :schema_name => XSD::QName.new(NsWebservices, "DeleteMarketplaceAdList"),
+    :schema_element => [
+      ["accountID", "SOAP::SOAPString"],
+      ["marketplaceAdIDList", "ChannelAdvisor::MarketplaceAdServiceSOAP::ArrayOfInt", [0, 1]]
+    ]
+  )
+
+  LiteralRegistry.register(
+    :class => ChannelAdvisor::MarketplaceAdServiceSOAP::DeleteMarketplaceAdListResponse,
+    :schema_name => XSD::QName.new(NsWebservices, "DeleteMarketplaceAdListResponse"),
+    :schema_element => [
+      ["deleteMarketplaceAdListResult", ["ChannelAdvisor::MarketplaceAdServiceSOAP::APIResultOfBoolean", XSD::QName.new(NsWebservices, "DeleteMarketplaceAdListResult")], [0, 1]]
     ]
   )
 

--- a/lib/channel_advisor/marketplace_ad_service/types.rb
+++ b/lib/channel_advisor/marketplace_ad_service/types.rb
@@ -10,7 +10,7 @@ module ChannelAdvisor; module MarketplaceAdServiceSOAP
 #   postingTemplate - SOAP::SOAPString
 #   adTemplate - SOAP::SOAPString
 #   schedule - SOAP::SOAPString
-#   flagStyle - ChannelAdvisor::MarketplaceAdServiceSOAP::FlagType
+#   flagStyle - SOAP::SOAPString
 #   flagDescription - SOAP::SOAPString
 #   primaryCategory - SOAP::SOAPString
 #   secondaryCategory - SOAP::SOAPString
@@ -162,6 +162,10 @@ class APIResultOfBoolean
   end
 end
 
+# {http://api.channeladvisor.com/webservices/}ArrayOfInt
+class ArrayOfInt < ::Array
+end
+
 # {http://api.channeladvisor.com/webservices/}APIResultOfString
 #   status - ChannelAdvisor::MarketplaceAdServiceSOAP::ResultStatus
 #   messageCode - SOAP::SOAPInt
@@ -182,19 +186,6 @@ class APIResultOfString
     @data = data
     @resultData = resultData
   end
-end
-
-# {http://api.channeladvisor.com/webservices/}FlagType
-class FlagType < ::String
-  BlueFlag = new("BlueFlag")
-  ExclamationPoint = new("ExclamationPoint")
-  GreenFlag = new("GreenFlag")
-  NoFlag = new("NoFlag")
-  NotAvailable = new("NotAvailable")
-  Price = new("Price")
-  QuestionMark = new("QuestionMark")
-  RedFlag = new("RedFlag")
-  YellowFlag = new("YellowFlag")
 end
 
 # {http://api.channeladvisor.com/webservices/}ResultStatus
@@ -232,7 +223,7 @@ end
 #   postingTemplate - SOAP::SOAPString
 #   adTemplate - SOAP::SOAPString
 #   schedule - SOAP::SOAPString
-#   flagStyle - ChannelAdvisor::MarketplaceAdServiceSOAP::FlagType
+#   flagStyle - SOAP::SOAPString
 #   flagDescription - SOAP::SOAPString
 #   primaryCategory - SOAP::SOAPString
 #   secondaryCategory - SOAP::SOAPString
@@ -296,6 +287,29 @@ class DeleteMarketplaceAdResponse
 
   def initialize(deleteMarketplaceAdResult = nil)
     @deleteMarketplaceAdResult = deleteMarketplaceAdResult
+  end
+end
+
+# {http://api.channeladvisor.com/webservices/}DeleteMarketplaceAdList
+#   accountID - SOAP::SOAPString
+#   marketplaceAdIDList - ChannelAdvisor::MarketplaceAdServiceSOAP::ArrayOfInt
+class DeleteMarketplaceAdList
+  attr_accessor :accountID
+  attr_accessor :marketplaceAdIDList
+
+  def initialize(accountID = nil, marketplaceAdIDList = nil)
+    @accountID = accountID
+    @marketplaceAdIDList = marketplaceAdIDList
+  end
+end
+
+# {http://api.channeladvisor.com/webservices/}DeleteMarketplaceAdListResponse
+#   deleteMarketplaceAdListResult - ChannelAdvisor::MarketplaceAdServiceSOAP::APIResultOfBoolean
+class DeleteMarketplaceAdListResponse
+  attr_accessor :deleteMarketplaceAdListResult
+
+  def initialize(deleteMarketplaceAdListResult = nil)
+    @deleteMarketplaceAdListResult = deleteMarketplaceAdListResult
   end
 end
 

--- a/lib/channel_advisor/order_service/client.rb
+++ b/lib/channel_advisor/order_service/client.rb
@@ -6,7 +6,7 @@ module ChannelAdvisor
 module OrderServiceSOAP
 
 class OrderServiceSoap < ::SOAP::RPC::Driver
-  DefaultEndpointUrl = "https://api.channeladvisor.com/ChannelAdvisorAPI/v4/OrderService.asmx"
+  DefaultEndpointUrl = "https://api.channeladvisor.com/ChannelAdvisorAPI/v7/OrderService.asmx"
 
   Methods = [
     [ "http://api.channeladvisor.com/webservices/SetOrdersExportStatus",
@@ -21,22 +21,6 @@ class OrderServiceSoap < ::SOAP::RPC::Driver
       "submitOrderRefund",
       [ [:in, "parameters", ["::SOAP::SOAPElement", "http://api.channeladvisor.com/webservices/", "SubmitOrderRefund"]],
         [:out, "parameters", ["::SOAP::SOAPElement", "http://api.channeladvisor.com/webservices/", "SubmitOrderRefundResponse"]] ],
-      { :request_style =>  :document, :request_use =>  :literal,
-        :response_style => :document, :response_use => :literal,
-        :faults => {} }
-    ],
-    [ "http://api.channeladvisor.com/webservices/GetOrderList",
-      "getOrderList",
-      [ [:in, "parameters", ["::SOAP::SOAPElement", "http://api.channeladvisor.com/webservices/", "GetOrderList"]],
-        [:out, "parameters", ["::SOAP::SOAPElement", "http://api.channeladvisor.com/webservices/", "GetOrderListResponse"]] ],
-      { :request_style =>  :document, :request_use =>  :literal,
-        :response_style => :document, :response_use => :literal,
-        :faults => {} }
-    ],
-    [ "http://api.channeladvisor.com/webservices/SubmitOrder",
-      "submitOrder",
-      [ [:in, "parameters", ["::SOAP::SOAPElement", "http://api.channeladvisor.com/webservices/", "SubmitOrder"]],
-        [:out, "parameters", ["::SOAP::SOAPElement", "http://api.channeladvisor.com/webservices/", "SubmitOrderResponse"]] ],
       { :request_style =>  :document, :request_use =>  :literal,
         :response_style => :document, :response_use => :literal,
         :faults => {} }
@@ -69,6 +53,38 @@ class OrderServiceSoap < ::SOAP::RPC::Driver
       "updateOrderList",
       [ [:in, "parameters", ["::SOAP::SOAPElement", "http://api.channeladvisor.com/webservices/", "UpdateOrderList"]],
         [:out, "parameters", ["::SOAP::SOAPElement", "http://api.channeladvisor.com/webservices/", "UpdateOrderListResponse"]] ],
+      { :request_style =>  :document, :request_use =>  :literal,
+        :response_style => :document, :response_use => :literal,
+        :faults => {} }
+    ],
+    [ "http://api.channeladvisor.com/webservices/OrderMerge",
+      "orderMerge",
+      [ [:in, "parameters", ["::SOAP::SOAPElement", "http://api.channeladvisor.com/webservices/", "OrderMerge"]],
+        [:out, "parameters", ["::SOAP::SOAPElement", "http://api.channeladvisor.com/webservices/", "OrderMergeResponse"]] ],
+      { :request_style =>  :document, :request_use =>  :literal,
+        :response_style => :document, :response_use => :literal,
+        :faults => {} }
+    ],
+    [ "http://api.channeladvisor.com/webservices/OrderSplit",
+      "orderSplit",
+      [ [:in, "parameters", ["::SOAP::SOAPElement", "http://api.channeladvisor.com/webservices/", "OrderSplit"]],
+        [:out, "parameters", ["::SOAP::SOAPElement", "http://api.channeladvisor.com/webservices/", "OrderSplitResponse"]] ],
+      { :request_style =>  :document, :request_use =>  :literal,
+        :response_style => :document, :response_use => :literal,
+        :faults => {} }
+    ],
+    [ "http://api.channeladvisor.com/webservices/SubmitOrder",
+      "submitOrder",
+      [ [:in, "parameters", ["::SOAP::SOAPElement", "http://api.channeladvisor.com/webservices/", "SubmitOrder"]],
+        [:out, "parameters", ["::SOAP::SOAPElement", "http://api.channeladvisor.com/webservices/", "SubmitOrderResponse"]] ],
+      { :request_style =>  :document, :request_use =>  :literal,
+        :response_style => :document, :response_use => :literal,
+        :faults => {} }
+    ],
+    [ "http://api.channeladvisor.com/webservices/GetOrderList",
+      "getOrderList",
+      [ [:in, "parameters", ["::SOAP::SOAPElement", "http://api.channeladvisor.com/webservices/", "GetOrderList"]],
+        [:out, "parameters", ["::SOAP::SOAPElement", "http://api.channeladvisor.com/webservices/", "GetOrderListResponse"]] ],
       { :request_style =>  :document, :request_use =>  :literal,
         :response_style => :document, :response_use => :literal,
         :faults => {} }

--- a/lib/channel_advisor/order_service/mapping_registry.rb
+++ b/lib/channel_advisor/order_service/mapping_registry.rb
@@ -10,6 +10,14 @@ module DefaultMappingRegistry
   NsWebservices = "http://api.channeladvisor.com/webservices/"
 
   EncodedRegistry.register(
+    :class => ChannelAdvisor::OrderServiceSOAP::ArrayOfInt,
+    :schema_type => XSD::QName.new(NsWebservices, "ArrayOfInt"),
+    :schema_element => [
+      ["int", "SOAP::SOAPInt[]", [0, nil]]
+    ]
+  )
+
+  EncodedRegistry.register(
     :class => ChannelAdvisor::OrderServiceSOAP::ArrayOfString,
     :schema_type => XSD::QName.new(NsWebservices, "ArrayOfString"),
     :schema_element => [
@@ -18,22 +26,32 @@ module DefaultMappingRegistry
   )
 
   EncodedRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::APIResultOfArrayOfBoolean,
-    :schema_type => XSD::QName.new(NsWebservices, "APIResultOfArrayOfBoolean"),
+    :class => ChannelAdvisor::OrderServiceSOAP::APIResultOfArrayOfSetExportStatusResponse,
+    :schema_type => XSD::QName.new(NsWebservices, "APIResultOfArrayOfSetExportStatusResponse"),
     :schema_element => [
       ["status", ["ChannelAdvisor::OrderServiceSOAP::ResultStatus", XSD::QName.new(NsWebservices, "Status")]],
       ["messageCode", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "MessageCode")]],
       ["message", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Message")], [0, 1]],
       ["data", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Data")], [0, 1]],
-      ["resultData", ["ChannelAdvisor::OrderServiceSOAP::ArrayOfBoolean", XSD::QName.new(NsWebservices, "ResultData")], [0, 1]]
+      ["resultData", ["ChannelAdvisor::OrderServiceSOAP::ArrayOfSetExportStatusResponse", XSD::QName.new(NsWebservices, "ResultData")], [0, 1]]
     ]
   )
 
   EncodedRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::ArrayOfBoolean,
-    :schema_type => XSD::QName.new(NsWebservices, "ArrayOfBoolean"),
+    :class => ChannelAdvisor::OrderServiceSOAP::ArrayOfSetExportStatusResponse,
+    :schema_type => XSD::QName.new(NsWebservices, "ArrayOfSetExportStatusResponse"),
     :schema_element => [
-      ["boolean", "SOAP::SOAPBoolean[]", [0, nil]]
+      ["setExportStatusResponse", ["ChannelAdvisor::OrderServiceSOAP::SetExportStatusResponse[]", XSD::QName.new(NsWebservices, "SetExportStatusResponse")], [0, nil]]
+    ]
+  )
+
+  EncodedRegistry.register(
+    :class => ChannelAdvisor::OrderServiceSOAP::SetExportStatusResponse,
+    :schema_type => XSD::QName.new(NsWebservices, "SetExportStatusResponse"),
+    :schema_element => [
+      ["orderID", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "OrderID")]],
+      ["clientOrderIdentifier", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "ClientOrderIdentifier")], [0, 1]],
+      ["success", ["SOAP::SOAPBoolean", XSD::QName.new(NsWebservices, "Success")]]
     ]
   )
 
@@ -59,46 +77,6 @@ module DefaultMappingRegistry
   )
 
   EncodedRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::APIResultOfArrayOfOrderResponseItem,
-    :schema_type => XSD::QName.new(NsWebservices, "APIResultOfArrayOfOrderResponseItem"),
-    :schema_element => [
-      ["status", ["ChannelAdvisor::OrderServiceSOAP::ResultStatus", XSD::QName.new(NsWebservices, "Status")]],
-      ["messageCode", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "MessageCode")]],
-      ["message", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Message")], [0, 1]],
-      ["data", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Data")], [0, 1]],
-      ["resultData", ["ChannelAdvisor::OrderServiceSOAP::ArrayOfOrderResponseItem", XSD::QName.new(NsWebservices, "ResultData")], [0, 1]]
-    ]
-  )
-
-  EncodedRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::ArrayOfOrderResponseItem,
-    :schema_type => XSD::QName.new(NsWebservices, "ArrayOfOrderResponseItem"),
-    :schema_element => [
-      ["orderResponseItem", ["ChannelAdvisor::OrderServiceSOAP::OrderResponseItem[]", XSD::QName.new(NsWebservices, "OrderResponseItem")], [0, nil]]
-    ]
-  )
-
-  EncodedRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::APIResultOfInt32,
-    :schema_type => XSD::QName.new(NsWebservices, "APIResultOfInt32"),
-    :schema_element => [
-      ["status", ["ChannelAdvisor::OrderServiceSOAP::ResultStatus", XSD::QName.new(NsWebservices, "Status")]],
-      ["messageCode", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "MessageCode")]],
-      ["message", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Message")], [0, 1]],
-      ["data", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Data")], [0, 1]],
-      ["resultData", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "ResultData")]]
-    ]
-  )
-
-  EncodedRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::ArrayOfInt,
-    :schema_type => XSD::QName.new(NsWebservices, "ArrayOfInt"),
-    :schema_element => [
-      ["int", "SOAP::SOAPInt[]", [0, nil]]
-    ]
-  )
-
-  EncodedRegistry.register(
     :class => ChannelAdvisor::OrderServiceSOAP::APIResultOfArrayOfInt32,
     :schema_type => XSD::QName.new(NsWebservices, "APIResultOfArrayOfInt32"),
     :schema_element => [
@@ -107,6 +85,26 @@ module DefaultMappingRegistry
       ["message", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Message")], [0, 1]],
       ["data", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Data")], [0, 1]],
       ["resultData", ["ChannelAdvisor::OrderServiceSOAP::ArrayOfInt", XSD::QName.new(NsWebservices, "ResultData")], [0, 1]]
+    ]
+  )
+
+  EncodedRegistry.register(
+    :class => ChannelAdvisor::OrderServiceSOAP::APIResultOfArrayOfBoolean,
+    :schema_type => XSD::QName.new(NsWebservices, "APIResultOfArrayOfBoolean"),
+    :schema_element => [
+      ["status", ["ChannelAdvisor::OrderServiceSOAP::ResultStatus", XSD::QName.new(NsWebservices, "Status")]],
+      ["messageCode", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "MessageCode")]],
+      ["message", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Message")], [0, 1]],
+      ["data", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Data")], [0, 1]],
+      ["resultData", ["ChannelAdvisor::OrderServiceSOAP::ArrayOfBoolean", XSD::QName.new(NsWebservices, "ResultData")], [0, 1]]
+    ]
+  )
+
+  EncodedRegistry.register(
+    :class => ChannelAdvisor::OrderServiceSOAP::ArrayOfBoolean,
+    :schema_type => XSD::QName.new(NsWebservices, "ArrayOfBoolean"),
+    :schema_element => [
+      ["boolean", "SOAP::SOAPBoolean[]", [0, nil]]
     ]
   )
 
@@ -135,10 +133,15 @@ module DefaultMappingRegistry
     :schema_type => XSD::QName.new(NsWebservices, "OrderUpdateSubmit"),
     :schema_element => [
       ["orderID", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "OrderID")]],
-      ["flagStyle", ["ChannelAdvisor::OrderServiceSOAP::FlagType", XSD::QName.new(NsWebservices, "FlagStyle")]],
+      ["newClientOrderIdentifier", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "NewClientOrderIdentifier")], [0, 1]],
+      ["flagStyle", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "FlagStyle")], [0, 1]],
       ["flagDescription", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "FlagDescription")], [0, 1]],
       ["transactionNotes", ["ChannelAdvisor::OrderServiceSOAP::TransactionNoteSubmit", XSD::QName.new(NsWebservices, "TransactionNotes")], [0, 1]],
-      ["orderStatusUpdate", ["ChannelAdvisor::OrderServiceSOAP::OrderStatusUpdateSubmit", XSD::QName.new(NsWebservices, "OrderStatusUpdate")], [0, 1]]
+      ["orderStatusUpdate", ["ChannelAdvisor::OrderServiceSOAP::OrderStatusUpdateSubmit", XSD::QName.new(NsWebservices, "OrderStatusUpdate")], [0, 1]],
+      ["billingInfo", ["ChannelAdvisor::OrderServiceSOAP::BillingInfoUpdateSubmit", XSD::QName.new(NsWebservices, "BillingInfo")], [0, 1]],
+      ["shippingInfo", ["ChannelAdvisor::OrderServiceSOAP::ShippingInfoUpdateSubmit", XSD::QName.new(NsWebservices, "ShippingInfo")], [0, 1]],
+      ["paymentInfo", ["ChannelAdvisor::OrderServiceSOAP::PaymentInfoUpdateSubmit", XSD::QName.new(NsWebservices, "PaymentInfo")], [0, 1]],
+      ["requestedShippingMethodInfo", ["ChannelAdvisor::OrderServiceSOAP::ShippingMethodInfoUpdateSubmit", XSD::QName.new(NsWebservices, "RequestedShippingMethodInfo")], [0, 1]]
     ]
   )
 
@@ -155,8 +158,17 @@ module DefaultMappingRegistry
     :class => ChannelAdvisor::OrderServiceSOAP::OrderStatusUpdateSubmit,
     :schema_type => XSD::QName.new(NsWebservices, "OrderStatusUpdateSubmit"),
     :schema_element => [
-      ["checkoutPaymentStatus", ["ChannelAdvisor::OrderServiceSOAP::CheckoutPaymentStatusCode", XSD::QName.new(NsWebservices, "CheckoutPaymentStatus")]],
-      ["shippingStatus", ["ChannelAdvisor::OrderServiceSOAP::ShippingStatusCode", XSD::QName.new(NsWebservices, "ShippingStatus")]]
+      ["checkoutPaymentStatus", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "CheckoutPaymentStatus")], [0, 1]],
+      ["shippingStatus", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "ShippingStatus")], [0, 1]]
+    ]
+  )
+
+  EncodedRegistry.register(
+    :class => ChannelAdvisor::OrderServiceSOAP::ShippingMethodInfoUpdateSubmit,
+    :schema_type => XSD::QName.new(NsWebservices, "ShippingMethodInfoUpdateSubmit"),
+    :schema_element => [
+      ["carrierCode", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "CarrierCode")], [0, 1]],
+      ["classCode", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "ClassCode")], [0, 1]]
     ]
   )
 
@@ -187,7 +199,57 @@ module DefaultMappingRegistry
       ["flagAndNotesSuccess", ["SOAP::SOAPBoolean", XSD::QName.new(NsWebservices, "FlagAndNotesSuccess")]],
       ["flagAndNotesMessage", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "FlagAndNotesMessage")], [0, 1]],
       ["orderStatusSuccess", ["SOAP::SOAPBoolean", XSD::QName.new(NsWebservices, "OrderStatusSuccess")]],
-      ["orderStatusMessage", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "OrderStatusMessage")], [0, 1]]
+      ["orderStatusMessage", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "OrderStatusMessage")], [0, 1]],
+      ["shippingAndCOIDSuccess", ["SOAP::SOAPBoolean", XSD::QName.new(NsWebservices, "ShippingAndCOIDSuccess")]],
+      ["shippingAndCOIDMessage", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "ShippingAndCOIDMessage")], [0, 1]],
+      ["billingAndPaymentSuccess", ["SOAP::SOAPBoolean", XSD::QName.new(NsWebservices, "BillingAndPaymentSuccess")]],
+      ["billingAndPaymentMessage", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "BillingAndPaymentMessage")], [0, 1]],
+      ["requestedShippingMethodSuccess", ["SOAP::SOAPBoolean", XSD::QName.new(NsWebservices, "RequestedShippingMethodSuccess")]],
+      ["requestedShippingMethodMessage", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "RequestedShippingMethodMessage")], [0, 1]]
+    ]
+  )
+
+  EncodedRegistry.register(
+    :class => ChannelAdvisor::OrderServiceSOAP::APIResultOfBoolean,
+    :schema_type => XSD::QName.new(NsWebservices, "APIResultOfBoolean"),
+    :schema_element => [
+      ["status", ["ChannelAdvisor::OrderServiceSOAP::ResultStatus", XSD::QName.new(NsWebservices, "Status")]],
+      ["messageCode", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "MessageCode")]],
+      ["message", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Message")], [0, 1]],
+      ["data", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Data")], [0, 1]],
+      ["resultData", ["SOAP::SOAPBoolean", XSD::QName.new(NsWebservices, "ResultData")]]
+    ]
+  )
+
+  EncodedRegistry.register(
+    :class => ChannelAdvisor::OrderServiceSOAP::APIResultOfInt32,
+    :schema_type => XSD::QName.new(NsWebservices, "APIResultOfInt32"),
+    :schema_element => [
+      ["status", ["ChannelAdvisor::OrderServiceSOAP::ResultStatus", XSD::QName.new(NsWebservices, "Status")]],
+      ["messageCode", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "MessageCode")]],
+      ["message", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Message")], [0, 1]],
+      ["data", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Data")], [0, 1]],
+      ["resultData", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "ResultData")]]
+    ]
+  )
+
+  EncodedRegistry.register(
+    :class => ChannelAdvisor::OrderServiceSOAP::APIResultOfArrayOfOrderResponseItem,
+    :schema_type => XSD::QName.new(NsWebservices, "APIResultOfArrayOfOrderResponseItem"),
+    :schema_element => [
+      ["status", ["ChannelAdvisor::OrderServiceSOAP::ResultStatus", XSD::QName.new(NsWebservices, "Status")]],
+      ["messageCode", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "MessageCode")]],
+      ["message", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Message")], [0, 1]],
+      ["data", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Data")], [0, 1]],
+      ["resultData", ["ChannelAdvisor::OrderServiceSOAP::ArrayOfOrderResponseItem", XSD::QName.new(NsWebservices, "ResultData")], [0, 1]]
+    ]
+  )
+
+  EncodedRegistry.register(
+    :class => ChannelAdvisor::OrderServiceSOAP::ArrayOfOrderResponseItem,
+    :schema_type => XSD::QName.new(NsWebservices, "ArrayOfOrderResponseItem"),
+    :schema_element => [
+      ["orderResponseItem", ["ChannelAdvisor::OrderServiceSOAP::OrderResponseItem[]", XSD::QName.new(NsWebservices, "OrderResponseItem")], [0, nil]]
     ]
   )
 
@@ -210,7 +272,7 @@ module DefaultMappingRegistry
       ["clientOrderIdentifier", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ClientOrderIdentifier")], [0, 1]],
       ["orderID", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "OrderID")]],
       ["amount", ["SOAP::SOAPDecimal", XSD::QName.new(NsOrders, "Amount")]],
-      ["adjustmentReason", ["ChannelAdvisor::OrderServiceSOAP::RefundAdjustmentReason", XSD::QName.new(NsOrders, "AdjustmentReason")]],
+      ["adjustmentReason", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "AdjustmentReason")], [0, 1]],
       ["sellerRefundID", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "SellerRefundID")], [0, 1]],
       ["refundItems", ["ChannelAdvisor::OrderServiceSOAP::ArrayOfRefundItem", XSD::QName.new(NsOrders, "RefundItems")], [0, 1]]
     ]
@@ -235,12 +297,14 @@ module DefaultMappingRegistry
       ["taxAmount", ["SOAP::SOAPDecimal", XSD::QName.new(NsOrders, "TaxAmount")]],
       ["giftWrapAmount", ["SOAP::SOAPDecimal", XSD::QName.new(NsOrders, "GiftWrapAmount")]],
       ["giftWrapTaxAmount", ["SOAP::SOAPDecimal", XSD::QName.new(NsOrders, "GiftWrapTaxAmount")]],
+      ["recyclingFee", ["SOAP::SOAPDecimal", XSD::QName.new(NsOrders, "RecyclingFee")]],
       ["quantity", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "Quantity")]],
       ["refundRequestID", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "RefundRequestID")]],
       ["refundRequested", ["SOAP::SOAPBoolean", XSD::QName.new(NsOrders, "RefundRequested")]],
       ["restockQuantity", ["SOAP::SOAPBoolean", XSD::QName.new(NsOrders, "RestockQuantity")]],
-      ["adjustmentReason", ["ChannelAdvisor::OrderServiceSOAP::RefundAdjustmentReason", XSD::QName.new(NsOrders, "AdjustmentReason")]],
-      ["sellerRefundID", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "SellerRefundID")], [0, 1]]
+      ["adjustmentReason", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "AdjustmentReason")], [0, 1]],
+      ["sellerRefundID", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "SellerRefundID")], [0, 1]],
+      ["lineItemID", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "LineItemID")]]
     ]
   )
 
@@ -256,17 +320,19 @@ module DefaultMappingRegistry
       ["taxAmount", ["SOAP::SOAPDecimal", XSD::QName.new(NsOrders, "TaxAmount")]],
       ["giftWrapAmount", ["SOAP::SOAPDecimal", XSD::QName.new(NsOrders, "GiftWrapAmount")]],
       ["giftWrapTaxAmount", ["SOAP::SOAPDecimal", XSD::QName.new(NsOrders, "GiftWrapTaxAmount")]],
+      ["recyclingFee", ["SOAP::SOAPDecimal", XSD::QName.new(NsOrders, "RecyclingFee")]],
       ["quantity", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "Quantity")]],
       ["refundRequestID", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "RefundRequestID")]],
       ["refundRequested", ["SOAP::SOAPBoolean", XSD::QName.new(NsOrders, "RefundRequested")]],
       ["restockQuantity", ["SOAP::SOAPBoolean", XSD::QName.new(NsOrders, "RestockQuantity")]],
-      ["adjustmentReason", ["ChannelAdvisor::OrderServiceSOAP::RefundAdjustmentReason", XSD::QName.new(NsOrders, "AdjustmentReason")]],
+      ["adjustmentReason", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "AdjustmentReason")], [0, 1]],
       ["sellerRefundID", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "SellerRefundID")], [0, 1]],
+      ["lineItemID", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "LineItemID")]],
       ["invoiceItemID", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "InvoiceItemID")]],
-      ["itemSaleSource", ["ChannelAdvisor::OrderServiceSOAP::SiteToken", XSD::QName.new(NsOrders, "ItemSaleSource")]],
-      ["refundRequestStatus", ["ChannelAdvisor::OrderServiceSOAP::AsyncStatusCode", XSD::QName.new(NsOrders, "RefundRequestStatus")]],
+      ["itemSaleSource", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ItemSaleSource")], [0, 1]],
+      ["refundRequestStatus", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "RefundRequestStatus")], [0, 1]],
       ["refundPaymentInfo", ["ChannelAdvisor::OrderServiceSOAP::PaymentInfo", XSD::QName.new(NsOrders, "RefundPaymentInfo")], [0, 1]],
-      ["restockStatus", ["ChannelAdvisor::OrderServiceSOAP::AsyncStatusCode", XSD::QName.new(NsOrders, "RestockStatus")]],
+      ["restockStatus", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "RestockStatus")], [0, 1]],
       ["refundCreateDateGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "RefundCreateDateGMT")]]
     ]
   )
@@ -296,114 +362,34 @@ module DefaultMappingRegistry
   )
 
   EncodedRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::OrderCriteria,
-    :schema_type => XSD::QName.new(NsOrders, "OrderCriteria"),
+    :class => ChannelAdvisor::OrderServiceSOAP::OrderRefundHistoryResponse,
+    :schema_type => XSD::QName.new(NsOrders, "OrderRefundHistoryResponse"),
     :schema_element => [
-      ["orderCreationFilterBeginTimeGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "OrderCreationFilterBeginTimeGMT")]],
-      ["orderCreationFilterEndTimeGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "OrderCreationFilterEndTimeGMT")]],
-      ["statusUpdateFilterBeginTimeGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "StatusUpdateFilterBeginTimeGMT")]],
-      ["statusUpdateFilterEndTimeGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "StatusUpdateFilterEndTimeGMT")]],
-      ["joinDateFiltersWithOr", ["SOAP::SOAPBoolean", XSD::QName.new(NsOrders, "JoinDateFiltersWithOr")]],
-      ["detailLevel", ["ChannelAdvisor::OrderServiceSOAP::DetailLevelType", XSD::QName.new(NsOrders, "DetailLevel")]],
-      ["exportState", ["ChannelAdvisor::OrderServiceSOAP::ExportStateType", XSD::QName.new(NsOrders, "ExportState")]],
-      ["orderIDList", ["ChannelAdvisor::OrderServiceSOAP::ArrayOfInt_", XSD::QName.new(NsOrders, "OrderIDList")], [0, 1]],
-      ["orderStateFilter", ["ChannelAdvisor::OrderServiceSOAP::OrderStateCode", XSD::QName.new(NsOrders, "OrderStateFilter")]],
-      ["paymentStatusFilter", ["ChannelAdvisor::OrderServiceSOAP::PaymentStatusCode", XSD::QName.new(NsOrders, "PaymentStatusFilter")]],
-      ["checkoutStatusFilter", ["ChannelAdvisor::OrderServiceSOAP::CheckoutStatusCode", XSD::QName.new(NsOrders, "CheckoutStatusFilter")]],
-      ["shippingStatusFilter", ["ChannelAdvisor::OrderServiceSOAP::ShippingStatusCode", XSD::QName.new(NsOrders, "ShippingStatusFilter")]],
-      ["distributionCenterCode", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "DistributionCenterCode")], [0, 1]],
-      ["pageNumberFilter", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "PageNumberFilter")]],
-      ["pageSize", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "PageSize")]]
-    ]
-  )
-
-  EncodedRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::ArrayOfInt_,
-    :schema_type => XSD::QName.new(NsOrders, "ArrayOfInt"),
-    :schema_element => [
-      ["int", "SOAP::SOAPInt[]", [0, nil]]
-    ]
-  )
-
-  EncodedRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::OrderResponseDetailLow,
-    :schema_type => XSD::QName.new(NsOrders, "OrderResponseDetailLow"),
-    :schema_basetype => XSD::QName.new(NsOrders, "OrderResponseItem"),
-    :schema_element => [
-      ["numberOfMatches", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "NumberOfMatches")]],
-      ["orderTimeGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "OrderTimeGMT")]],
-      ["lastUpdateDate", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "LastUpdateDate")]],
-      ["totalOrderAmount", ["SOAP::SOAPDecimal", XSD::QName.new(NsOrders, "TotalOrderAmount")]],
-      ["orderState", ["ChannelAdvisor::OrderServiceSOAP::OrderStateCode", XSD::QName.new(NsOrders, "OrderState")]],
-      ["dateCancelledGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "DateCancelledGMT")]],
       ["orderID", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "OrderID")]],
       ["clientOrderIdentifier", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ClientOrderIdentifier")], [0, 1]],
-      ["flagStyle", ["ChannelAdvisor::OrderServiceSOAP::FlagType", XSD::QName.new(NsOrders, "FlagStyle")]],
-      ["orderStatus", ["ChannelAdvisor::OrderServiceSOAP::OrderStatus", XSD::QName.new(NsOrders, "OrderStatus")], [0, 1]]
+      ["refundStatus", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "RefundStatus")], [0, 1]],
+      ["lineItemRefunds", ["ChannelAdvisor::OrderServiceSOAP::ArrayOfOrderLineItemRefundHistoryResponse", XSD::QName.new(NsOrders, "LineItemRefunds")], [0, 1]]
     ]
   )
 
   EncodedRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::OrderStatus,
-    :schema_type => XSD::QName.new(NsOrders, "OrderStatus"),
+    :class => ChannelAdvisor::OrderServiceSOAP::ArrayOfOrderLineItemRefundHistoryResponse,
+    :schema_type => XSD::QName.new(NsOrders, "ArrayOfOrderLineItemRefundHistoryResponse"),
     :schema_element => [
-      ["checkoutStatus", ["ChannelAdvisor::OrderServiceSOAP::CheckoutStatusCode", XSD::QName.new(NsOrders, "CheckoutStatus")]],
-      ["checkoutDateGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "CheckoutDateGMT")]],
-      ["paymentStatus", ["ChannelAdvisor::OrderServiceSOAP::PaymentStatusCode", XSD::QName.new(NsOrders, "PaymentStatus")]],
-      ["paymentDateGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "PaymentDateGMT")]],
-      ["shippingStatus", ["ChannelAdvisor::OrderServiceSOAP::ShippingStatusCode", XSD::QName.new(NsOrders, "ShippingStatus")]],
-      ["shippingDateGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "ShippingDateGMT")]],
-      ["orderRefundStatus", ["ChannelAdvisor::OrderServiceSOAP::OrderRefundStatusCode", XSD::QName.new(NsOrders, "OrderRefundStatus")]]
+      ["orderLineItemRefundHistoryResponse", ["ChannelAdvisor::OrderServiceSOAP::OrderLineItemRefundHistoryResponse[]", XSD::QName.new(NsOrders, "OrderLineItemRefundHistoryResponse")], [0, nil]]
     ]
   )
 
   EncodedRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::OrderResponseDetailMedium,
-    :schema_type => XSD::QName.new(NsOrders, "OrderResponseDetailMedium"),
-    :schema_basetype => XSD::QName.new(NsOrders, "OrderResponseDetailLow"),
-    :schema_element => [
-      ["numberOfMatches", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "NumberOfMatches")]],
-      ["orderTimeGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "OrderTimeGMT")]],
-      ["lastUpdateDate", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "LastUpdateDate")]],
-      ["totalOrderAmount", ["SOAP::SOAPDecimal", XSD::QName.new(NsOrders, "TotalOrderAmount")]],
-      ["orderState", ["ChannelAdvisor::OrderServiceSOAP::OrderStateCode", XSD::QName.new(NsOrders, "OrderState")]],
-      ["dateCancelledGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "DateCancelledGMT")]],
-      ["orderID", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "OrderID")]],
-      ["clientOrderIdentifier", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ClientOrderIdentifier")], [0, 1]],
-      ["flagStyle", ["ChannelAdvisor::OrderServiceSOAP::FlagType", XSD::QName.new(NsOrders, "FlagStyle")]],
-      ["orderStatus", ["ChannelAdvisor::OrderServiceSOAP::OrderStatus", XSD::QName.new(NsOrders, "OrderStatus")], [0, 1]],
-      ["resellerID", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ResellerID")], [0, 1]],
-      ["buyerEmailAddress", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "BuyerEmailAddress")], [0, 1]],
-      ["emailOptIn", ["SOAP::SOAPBoolean", XSD::QName.new(NsOrders, "EmailOptIn")]],
-      ["paymentInfo", ["ChannelAdvisor::OrderServiceSOAP::PaymentInfoResponse", XSD::QName.new(NsOrders, "PaymentInfo")], [0, 1]],
-      ["shippingInfo", ["ChannelAdvisor::OrderServiceSOAP::ShippingInfoResponse", XSD::QName.new(NsOrders, "ShippingInfo")], [0, 1]],
-      ["billingInfo", ["ChannelAdvisor::OrderServiceSOAP::BillingInfo", XSD::QName.new(NsOrders, "BillingInfo")], [0, 1]],
-      ["flagDescription", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "FlagDescription")], [0, 1]]
-    ]
-  )
-
-  EncodedRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::PaymentInfoResponse,
-    :schema_type => XSD::QName.new(NsOrders, "PaymentInfoResponse"),
-    :schema_basetype => XSD::QName.new(NsOrders, "PaymentInfo"),
-    :schema_element => [
-      ["paymentType", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "PaymentType")], [0, 1]],
-      ["creditCardLast4", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "CreditCardLast4")], [0, 1]],
-      ["payPalID", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "PayPalID")], [0, 1]],
-      ["merchantReferenceNumber", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "MerchantReferenceNumber")], [0, 1]],
-      ["paymentTransactionID", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "PaymentTransactionID")], [0, 1]]
-    ]
-  )
-
-  EncodedRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::ShippingInfoResponse,
-    :schema_type => XSD::QName.new(NsOrders, "ShippingInfoResponse"),
-    :schema_basetype => XSD::QName.new(NsOrders, "ShippingInfo"),
+    :class => ChannelAdvisor::OrderServiceSOAP::BillingInfoUpdateSubmit,
+    :schema_type => XSD::QName.new(NsOrders, "BillingInfoUpdateSubmit"),
+    :schema_basetype => XSD::QName.new(NsOrders, "BillingInfo"),
     :schema_element => [
       ["addressLine1", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "AddressLine1")], [0, 1]],
       ["addressLine2", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "AddressLine2")], [0, 1]],
       ["city", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "City")], [0, 1]],
       ["region", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "Region")], [0, 1]],
+      ["regionDescription", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "RegionDescription")], [0, 1]],
       ["postalCode", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "PostalCode")], [0, 1]],
       ["countryCode", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "CountryCode")], [0, 1]],
       ["companyName", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "CompanyName")], [0, 1]],
@@ -414,8 +400,30 @@ module DefaultMappingRegistry
       ["suffix", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "Suffix")], [0, 1]],
       ["phoneNumberDay", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "PhoneNumberDay")], [0, 1]],
       ["phoneNumberEvening", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "PhoneNumberEvening")], [0, 1]],
-      ["shipmentList", ["ChannelAdvisor::OrderServiceSOAP::ArrayOfShipment", XSD::QName.new(NsOrders, "ShipmentList")], [0, 1]],
-      ["shippingInstructions", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ShippingInstructions")], [0, 1]]
+      ["emailAddress", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "EmailAddress")], [0, 1]]
+    ]
+  )
+
+  EncodedRegistry.register(
+    :class => ChannelAdvisor::OrderServiceSOAP::BillingInfo,
+    :schema_type => XSD::QName.new(NsOrders, "BillingInfo"),
+    :schema_basetype => XSD::QName.new(NsOrders, "ContactComplete"),
+    :schema_element => [
+      ["addressLine1", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "AddressLine1")], [0, 1]],
+      ["addressLine2", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "AddressLine2")], [0, 1]],
+      ["city", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "City")], [0, 1]],
+      ["region", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "Region")], [0, 1]],
+      ["regionDescription", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "RegionDescription")], [0, 1]],
+      ["postalCode", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "PostalCode")], [0, 1]],
+      ["countryCode", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "CountryCode")], [0, 1]],
+      ["companyName", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "CompanyName")], [0, 1]],
+      ["jobTitle", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "JobTitle")], [0, 1]],
+      ["title", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "Title")], [0, 1]],
+      ["firstName", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "FirstName")], [0, 1]],
+      ["lastName", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "LastName")], [0, 1]],
+      ["suffix", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "Suffix")], [0, 1]],
+      ["phoneNumberDay", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "PhoneNumberDay")], [0, 1]],
+      ["phoneNumberEvening", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "PhoneNumberEvening")], [0, 1]]
     ]
   )
 
@@ -428,6 +436,7 @@ module DefaultMappingRegistry
       ["addressLine2", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "AddressLine2")], [0, 1]],
       ["city", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "City")], [0, 1]],
       ["region", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "Region")], [0, 1]],
+      ["regionDescription", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "RegionDescription")], [0, 1]],
       ["postalCode", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "PostalCode")], [0, 1]],
       ["countryCode", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "CountryCode")], [0, 1]],
       ["companyName", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "CompanyName")], [0, 1]],
@@ -449,20 +458,22 @@ module DefaultMappingRegistry
       ["addressLine2", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "AddressLine2")], [0, 1]],
       ["city", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "City")], [0, 1]],
       ["region", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "Region")], [0, 1]],
+      ["regionDescription", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "RegionDescription")], [0, 1]],
       ["postalCode", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "PostalCode")], [0, 1]],
       ["countryCode", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "CountryCode")], [0, 1]]
     ]
   )
 
   EncodedRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::BillingInfo,
-    :schema_type => XSD::QName.new(NsOrders, "BillingInfo"),
+    :class => ChannelAdvisor::OrderServiceSOAP::ShippingInfoUpdateSubmit,
+    :schema_type => XSD::QName.new(NsOrders, "ShippingInfoUpdateSubmit"),
     :schema_basetype => XSD::QName.new(NsOrders, "ContactComplete"),
     :schema_element => [
       ["addressLine1", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "AddressLine1")], [0, 1]],
       ["addressLine2", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "AddressLine2")], [0, 1]],
       ["city", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "City")], [0, 1]],
       ["region", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "Region")], [0, 1]],
+      ["regionDescription", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "RegionDescription")], [0, 1]],
       ["postalCode", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "PostalCode")], [0, 1]],
       ["countryCode", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "CountryCode")], [0, 1]],
       ["companyName", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "CompanyName")], [0, 1]],
@@ -472,51 +483,58 @@ module DefaultMappingRegistry
       ["lastName", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "LastName")], [0, 1]],
       ["suffix", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "Suffix")], [0, 1]],
       ["phoneNumberDay", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "PhoneNumberDay")], [0, 1]],
-      ["phoneNumberEvening", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "PhoneNumberEvening")], [0, 1]]
+      ["phoneNumberEvening", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "PhoneNumberEvening")], [0, 1]],
+      ["emailAddress", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "EmailAddress")], [0, 1]],
+      ["shippingInstructions", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ShippingInstructions")], [0, 1]],
+      ["estimatedShipDate", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "EstimatedShipDate")]],
+      ["deliveryDate", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "DeliveryDate")]]
     ]
   )
 
   EncodedRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::ArrayOfShipment,
-    :schema_type => XSD::QName.new(NsOrders, "ArrayOfShipment"),
+    :class => ChannelAdvisor::OrderServiceSOAP::PaymentInfoUpdateSubmit,
+    :schema_type => XSD::QName.new(NsOrders, "PaymentInfoUpdateSubmit"),
+    :schema_basetype => XSD::QName.new(NsOrders, "PaymentInfo"),
     :schema_element => [
-      ["shipment", ["ChannelAdvisor::OrderServiceSOAP::Shipment[]", XSD::QName.new(NsOrders, "Shipment")], [0, nil]]
+      ["paymentType", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "PaymentType")], [0, 1]],
+      ["creditCardLast4", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "CreditCardLast4")], [0, 1]],
+      ["payPalID", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "PayPalID")], [0, 1]],
+      ["merchantReferenceNumber", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "MerchantReferenceNumber")], [0, 1]],
+      ["paymentTransactionID", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "PaymentTransactionID")], [0, 1]]
     ]
   )
 
   EncodedRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::Shipment,
-    :schema_type => XSD::QName.new(NsOrders, "Shipment"),
+    :class => ChannelAdvisor::OrderServiceSOAP::OrderSubmit,
+    :schema_type => XSD::QName.new(NsOrders, "OrderSubmit"),
+    :schema_basetype => XSD::QName.new(NsOrders, "Order"),
     :schema_element => [
-      ["shippingCarrier", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ShippingCarrier")], [0, 1]],
-      ["shippingClass", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ShippingClass")], [0, 1]],
-      ["trackingNumber", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "TrackingNumber")], [0, 1]]
-    ]
-  )
-
-  EncodedRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::OrderResponseDetailHigh,
-    :schema_type => XSD::QName.new(NsOrders, "OrderResponseDetailHigh"),
-    :schema_basetype => XSD::QName.new(NsOrders, "OrderResponseDetailMedium"),
-    :schema_element => [
-      ["numberOfMatches", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "NumberOfMatches")]],
       ["orderTimeGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "OrderTimeGMT")]],
-      ["lastUpdateDate", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "LastUpdateDate")]],
-      ["totalOrderAmount", ["SOAP::SOAPDecimal", XSD::QName.new(NsOrders, "TotalOrderAmount")]],
-      ["orderState", ["ChannelAdvisor::OrderServiceSOAP::OrderStateCode", XSD::QName.new(NsOrders, "OrderState")]],
-      ["dateCancelledGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "DateCancelledGMT")]],
-      ["orderID", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "OrderID")]],
       ["clientOrderIdentifier", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ClientOrderIdentifier")], [0, 1]],
-      ["flagStyle", ["ChannelAdvisor::OrderServiceSOAP::FlagType", XSD::QName.new(NsOrders, "FlagStyle")]],
+      ["sellerOrderID", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "SellerOrderID")], [0, 1]],
       ["orderStatus", ["ChannelAdvisor::OrderServiceSOAP::OrderStatus", XSD::QName.new(NsOrders, "OrderStatus")], [0, 1]],
-      ["resellerID", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ResellerID")], [0, 1]],
       ["buyerEmailAddress", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "BuyerEmailAddress")], [0, 1]],
       ["emailOptIn", ["SOAP::SOAPBoolean", XSD::QName.new(NsOrders, "EmailOptIn")]],
-      ["paymentInfo", ["ChannelAdvisor::OrderServiceSOAP::PaymentInfoResponse", XSD::QName.new(NsOrders, "PaymentInfo")], [0, 1]],
-      ["shippingInfo", ["ChannelAdvisor::OrderServiceSOAP::ShippingInfoResponse", XSD::QName.new(NsOrders, "ShippingInfo")], [0, 1]],
+      ["resellerID", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ResellerID")], [0, 1]],
       ["billingInfo", ["ChannelAdvisor::OrderServiceSOAP::BillingInfo", XSD::QName.new(NsOrders, "BillingInfo")], [0, 1]],
-      ["flagDescription", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "FlagDescription")], [0, 1]],
-      ["shoppingCart", ["ChannelAdvisor::OrderServiceSOAP::OrderCart", XSD::QName.new(NsOrders, "ShoppingCart")], [0, 1]]
+      ["paymentInfo", ["ChannelAdvisor::OrderServiceSOAP::PaymentInfo", XSD::QName.new(NsOrders, "PaymentInfo")], [0, 1]],
+      ["shoppingCart", ["ChannelAdvisor::OrderServiceSOAP::OrderCart", XSD::QName.new(NsOrders, "ShoppingCart")], [0, 1]],
+      ["customValueList", ["ChannelAdvisor::OrderServiceSOAP::ArrayOfCustomValue", XSD::QName.new(NsOrders, "CustomValueList")], [0, 1]],
+      ["shippingInfo", ["ChannelAdvisor::OrderServiceSOAP::ShippingInfoSubmit", XSD::QName.new(NsOrders, "ShippingInfo")], [0, 1]]
+    ]
+  )
+
+  EncodedRegistry.register(
+    :class => ChannelAdvisor::OrderServiceSOAP::OrderStatus,
+    :schema_type => XSD::QName.new(NsOrders, "OrderStatus"),
+    :schema_element => [
+      ["checkoutStatus", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "CheckoutStatus")], [0, 1]],
+      ["checkoutDateGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "CheckoutDateGMT")]],
+      ["paymentStatus", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "PaymentStatus")], [0, 1]],
+      ["paymentDateGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "PaymentDateGMT")]],
+      ["shippingStatus", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ShippingStatus")], [0, 1]],
+      ["shippingDateGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "ShippingDateGMT")]],
+      ["orderRefundStatus", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "OrderRefundStatus")], [0, 1]]
     ]
   )
 
@@ -525,10 +543,10 @@ module DefaultMappingRegistry
     :schema_type => XSD::QName.new(NsOrders, "OrderCart"),
     :schema_element => [
       ["cartID", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "CartID")]],
-      ["checkoutSource", ["ChannelAdvisor::OrderServiceSOAP::CheckoutSourceType", XSD::QName.new(NsOrders, "CheckoutSource")]],
-      ["vATTaxCalculationOption", ["ChannelAdvisor::OrderServiceSOAP::VAT_Calculation_Type", XSD::QName.new(NsOrders, "VATTaxCalculationOption")]],
-      ["vATShippingOption", ["ChannelAdvisor::OrderServiceSOAP::VAT_Calculation_Type", XSD::QName.new(NsOrders, "VATShippingOption")]],
-      ["vATGiftWrapOption", ["ChannelAdvisor::OrderServiceSOAP::VAT_Calculation_Type", XSD::QName.new(NsOrders, "VATGiftWrapOption")]],
+      ["checkoutSource", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "CheckoutSource")], [0, 1]],
+      ["vATTaxCalculationOption", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "VATTaxCalculationOption")], [0, 1]],
+      ["vATShippingOption", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "VATShippingOption")], [0, 1]],
+      ["vATGiftWrapOption", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "VATGiftWrapOption")], [0, 1]],
       ["lineItemSKUList", ["ChannelAdvisor::OrderServiceSOAP::ArrayOfOrderLineItemItem", XSD::QName.new(NsOrders, "LineItemSKUList")], [0, 1]],
       ["lineItemInvoiceList", ["ChannelAdvisor::OrderServiceSOAP::ArrayOfOrderLineItemInvoice", XSD::QName.new(NsOrders, "LineItemInvoiceList")], [0, 1]],
       ["lineItemPromoList", ["ChannelAdvisor::OrderServiceSOAP::ArrayOfOrderLineItemPromo", XSD::QName.new(NsOrders, "LineItemPromoList")], [0, 1]]
@@ -548,12 +566,12 @@ module DefaultMappingRegistry
     :schema_type => XSD::QName.new(NsOrders, "OrderLineItemItem"),
     :schema_basetype => XSD::QName.new(NsOrders, "OrderLineItemBase"),
     :schema_element => [
-      ["lineItemType", ["ChannelAdvisor::OrderServiceSOAP::LineItemTypeCode", XSD::QName.new(NsOrders, "LineItemType")]],
+      ["lineItemType", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "LineItemType")], [0, 1]],
       ["unitPrice", ["SOAP::SOAPDecimal", XSD::QName.new(NsOrders, "UnitPrice")]],
       ["lineItemID", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "LineItemID")]],
       ["allowNegativeQuantity", ["SOAP::SOAPBoolean", XSD::QName.new(NsOrders, "AllowNegativeQuantity")]],
       ["quantity", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "Quantity")]],
-      ["itemSaleSource", ["ChannelAdvisor::OrderServiceSOAP::SiteToken", XSD::QName.new(NsOrders, "ItemSaleSource")]],
+      ["itemSaleSource", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ItemSaleSource")], [0, 1]],
       ["sKU", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "SKU")], [0, 1]],
       ["title", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "Title")], [0, 1]],
       ["buyerUserID", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "BuyerUserID")], [0, 1]],
@@ -567,7 +585,9 @@ module DefaultMappingRegistry
       ["giftWrapTaxCost", ["SOAP::SOAPDecimal", XSD::QName.new(NsOrders, "GiftWrapTaxCost")]],
       ["giftMessage", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "GiftMessage")], [0, 1]],
       ["giftWrapLevel", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "GiftWrapLevel")], [0, 1]],
-      ["itemPromoList", ["ChannelAdvisor::OrderServiceSOAP::ArrayOfOrderLineItemItemPromo", XSD::QName.new(NsOrders, "ItemPromoList")], [0, 1]]
+      ["itemPromoList", ["ChannelAdvisor::OrderServiceSOAP::ArrayOfOrderLineItemItemPromo", XSD::QName.new(NsOrders, "ItemPromoList")], [0, 1]],
+      ["recyclingFee", ["SOAP::SOAPDecimal", XSD::QName.new(NsOrders, "RecyclingFee")]],
+      ["fulfillmentType", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "FulfillmentType")], [0, 1]]
     ]
   )
 
@@ -576,7 +596,7 @@ module DefaultMappingRegistry
     :schema_type => XSD::QName.new(NsOrders, "OrderLineItemPromo"),
     :schema_basetype => XSD::QName.new(NsOrders, "OrderLineItemBase"),
     :schema_element => [
-      ["lineItemType", ["ChannelAdvisor::OrderServiceSOAP::LineItemTypeCode", XSD::QName.new(NsOrders, "LineItemType")]],
+      ["lineItemType", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "LineItemType")], [0, 1]],
       ["unitPrice", ["SOAP::SOAPDecimal", XSD::QName.new(NsOrders, "UnitPrice")]],
       ["promoCode", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "PromoCode")], [0, 1]]
     ]
@@ -587,7 +607,7 @@ module DefaultMappingRegistry
     :schema_type => XSD::QName.new(NsOrders, "OrderLineItemItemPromo"),
     :schema_basetype => XSD::QName.new(NsOrders, "OrderLineItemPromo"),
     :schema_element => [
-      ["lineItemType", ["ChannelAdvisor::OrderServiceSOAP::LineItemTypeCode", XSD::QName.new(NsOrders, "LineItemType")]],
+      ["lineItemType", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "LineItemType")], [0, 1]],
       ["unitPrice", ["SOAP::SOAPDecimal", XSD::QName.new(NsOrders, "UnitPrice")]],
       ["promoCode", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "PromoCode")], [0, 1]],
       ["shippingPrice", ["SOAP::SOAPDecimal", XSD::QName.new(NsOrders, "ShippingPrice")]]
@@ -599,7 +619,7 @@ module DefaultMappingRegistry
     :schema_type => XSD::QName.new(NsOrders, "OrderLineItemInvoice"),
     :schema_basetype => XSD::QName.new(NsOrders, "OrderLineItemBase"),
     :schema_element => [
-      ["lineItemType", ["ChannelAdvisor::OrderServiceSOAP::LineItemTypeCode", XSD::QName.new(NsOrders, "LineItemType")]],
+      ["lineItemType", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "LineItemType")], [0, 1]],
       ["unitPrice", ["SOAP::SOAPDecimal", XSD::QName.new(NsOrders, "UnitPrice")]]
     ]
   )
@@ -617,12 +637,12 @@ module DefaultMappingRegistry
     :schema_type => XSD::QName.new(NsOrders, "OrderLineItemItemResponse"),
     :schema_basetype => XSD::QName.new(NsOrders, "OrderLineItemItem"),
     :schema_element => [
-      ["lineItemType", ["ChannelAdvisor::OrderServiceSOAP::LineItemTypeCode", XSD::QName.new(NsOrders, "LineItemType")]],
+      ["lineItemType", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "LineItemType")], [0, 1]],
       ["unitPrice", ["SOAP::SOAPDecimal", XSD::QName.new(NsOrders, "UnitPrice")]],
       ["lineItemID", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "LineItemID")]],
       ["allowNegativeQuantity", ["SOAP::SOAPBoolean", XSD::QName.new(NsOrders, "AllowNegativeQuantity")]],
       ["quantity", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "Quantity")]],
-      ["itemSaleSource", ["ChannelAdvisor::OrderServiceSOAP::SiteToken", XSD::QName.new(NsOrders, "ItemSaleSource")]],
+      ["itemSaleSource", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ItemSaleSource")], [0, 1]],
       ["sKU", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "SKU")], [0, 1]],
       ["title", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "Title")], [0, 1]],
       ["buyerUserID", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "BuyerUserID")], [0, 1]],
@@ -637,10 +657,14 @@ module DefaultMappingRegistry
       ["giftMessage", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "GiftMessage")], [0, 1]],
       ["giftWrapLevel", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "GiftWrapLevel")], [0, 1]],
       ["itemPromoList", ["ChannelAdvisor::OrderServiceSOAP::ArrayOfOrderLineItemItemPromo", XSD::QName.new(NsOrders, "ItemPromoList")], [0, 1]],
+      ["recyclingFee", ["SOAP::SOAPDecimal", XSD::QName.new(NsOrders, "RecyclingFee")]],
+      ["fulfillmentType", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "FulfillmentType")], [0, 1]],
       ["unitWeight", ["ChannelAdvisor::OrderServiceSOAP::ItemWeight", XSD::QName.new(NsOrders, "UnitWeight")], [0, 1]],
       ["warehouseLocation", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "WarehouseLocation")], [0, 1]],
       ["userName", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "UserName")], [0, 1]],
-      ["distributionCenterCode", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "DistributionCenterCode")], [0, 1]]
+      ["distributionCenterCode", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "DistributionCenterCode")], [0, 1]],
+      ["isExternallyFulfilled", ["SOAP::SOAPBoolean", XSD::QName.new(NsOrders, "IsExternallyFulfilled")]],
+      ["itemSaleSourceTransactionID", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ItemSaleSourceTransactionID")], [0, 1]]
     ]
   )
 
@@ -669,35 +693,6 @@ module DefaultMappingRegistry
   )
 
   EncodedRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::OrderResponseDetailComplete,
-    :schema_type => XSD::QName.new(NsOrders, "OrderResponseDetailComplete"),
-    :schema_basetype => XSD::QName.new(NsOrders, "OrderResponseDetailHigh"),
-    :schema_element => [
-      ["numberOfMatches", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "NumberOfMatches")]],
-      ["orderTimeGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "OrderTimeGMT")]],
-      ["lastUpdateDate", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "LastUpdateDate")]],
-      ["totalOrderAmount", ["SOAP::SOAPDecimal", XSD::QName.new(NsOrders, "TotalOrderAmount")]],
-      ["orderState", ["ChannelAdvisor::OrderServiceSOAP::OrderStateCode", XSD::QName.new(NsOrders, "OrderState")]],
-      ["dateCancelledGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "DateCancelledGMT")]],
-      ["orderID", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "OrderID")]],
-      ["clientOrderIdentifier", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ClientOrderIdentifier")], [0, 1]],
-      ["flagStyle", ["ChannelAdvisor::OrderServiceSOAP::FlagType", XSD::QName.new(NsOrders, "FlagStyle")]],
-      ["orderStatus", ["ChannelAdvisor::OrderServiceSOAP::OrderStatus", XSD::QName.new(NsOrders, "OrderStatus")], [0, 1]],
-      ["resellerID", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ResellerID")], [0, 1]],
-      ["buyerEmailAddress", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "BuyerEmailAddress")], [0, 1]],
-      ["emailOptIn", ["SOAP::SOAPBoolean", XSD::QName.new(NsOrders, "EmailOptIn")]],
-      ["paymentInfo", ["ChannelAdvisor::OrderServiceSOAP::PaymentInfoResponse", XSD::QName.new(NsOrders, "PaymentInfo")], [0, 1]],
-      ["shippingInfo", ["ChannelAdvisor::OrderServiceSOAP::ShippingInfoResponse", XSD::QName.new(NsOrders, "ShippingInfo")], [0, 1]],
-      ["billingInfo", ["ChannelAdvisor::OrderServiceSOAP::BillingInfo", XSD::QName.new(NsOrders, "BillingInfo")], [0, 1]],
-      ["flagDescription", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "FlagDescription")], [0, 1]],
-      ["shoppingCart", ["ChannelAdvisor::OrderServiceSOAP::OrderCart", XSD::QName.new(NsOrders, "ShoppingCart")], [0, 1]],
-      ["customValueList", ["ChannelAdvisor::OrderServiceSOAP::ArrayOfCustomValue", XSD::QName.new(NsOrders, "CustomValueList")], [0, 1]],
-      ["buyerIpAddress", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "BuyerIpAddress")], [0, 1]],
-      ["transactionNotes", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "TransactionNotes")], [0, 1]]
-    ]
-  )
-
-  EncodedRegistry.register(
     :class => ChannelAdvisor::OrderServiceSOAP::ArrayOfCustomValue,
     :schema_type => XSD::QName.new(NsOrders, "ArrayOfCustomValue"),
     :schema_element => [
@@ -715,25 +710,6 @@ module DefaultMappingRegistry
   )
 
   EncodedRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::OrderSubmit,
-    :schema_type => XSD::QName.new(NsOrders, "OrderSubmit"),
-    :schema_basetype => XSD::QName.new(NsOrders, "Order"),
-    :schema_element => [
-      ["orderTimeGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "OrderTimeGMT")]],
-      ["clientOrderIdentifier", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ClientOrderIdentifier")], [0, 1]],
-      ["orderStatus", ["ChannelAdvisor::OrderServiceSOAP::OrderStatus", XSD::QName.new(NsOrders, "OrderStatus")], [0, 1]],
-      ["buyerEmailAddress", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "BuyerEmailAddress")], [0, 1]],
-      ["emailOptIn", ["SOAP::SOAPBoolean", XSD::QName.new(NsOrders, "EmailOptIn")]],
-      ["resellerID", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ResellerID")], [0, 1]],
-      ["billingInfo", ["ChannelAdvisor::OrderServiceSOAP::BillingInfo", XSD::QName.new(NsOrders, "BillingInfo")], [0, 1]],
-      ["paymentInfo", ["ChannelAdvisor::OrderServiceSOAP::PaymentInfo", XSD::QName.new(NsOrders, "PaymentInfo")], [0, 1]],
-      ["shoppingCart", ["ChannelAdvisor::OrderServiceSOAP::OrderCart", XSD::QName.new(NsOrders, "ShoppingCart")], [0, 1]],
-      ["customValueList", ["ChannelAdvisor::OrderServiceSOAP::ArrayOfCustomValue", XSD::QName.new(NsOrders, "CustomValueList")], [0, 1]],
-      ["shippingInfo", ["ChannelAdvisor::OrderServiceSOAP::ShippingInfoSubmit", XSD::QName.new(NsOrders, "ShippingInfo")], [0, 1]]
-    ]
-  )
-
-  EncodedRegistry.register(
     :class => ChannelAdvisor::OrderServiceSOAP::ShippingInfoSubmit,
     :schema_type => XSD::QName.new(NsOrders, "ShippingInfoSubmit"),
     :schema_basetype => XSD::QName.new(NsOrders, "ShippingInfo"),
@@ -742,6 +718,7 @@ module DefaultMappingRegistry
       ["addressLine2", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "AddressLine2")], [0, 1]],
       ["city", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "City")], [0, 1]],
       ["region", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "Region")], [0, 1]],
+      ["regionDescription", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "RegionDescription")], [0, 1]],
       ["postalCode", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "PostalCode")], [0, 1]],
       ["countryCode", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "CountryCode")], [0, 1]],
       ["companyName", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "CompanyName")], [0, 1]],
@@ -753,26 +730,210 @@ module DefaultMappingRegistry
       ["phoneNumberDay", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "PhoneNumberDay")], [0, 1]],
       ["phoneNumberEvening", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "PhoneNumberEvening")], [0, 1]],
       ["shipmentList", ["ChannelAdvisor::OrderServiceSOAP::ArrayOfShipment", XSD::QName.new(NsOrders, "ShipmentList")], [0, 1]],
-      ["shippingInstructions", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ShippingInstructions")], [0, 1]]
+      ["shippingInstructions", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ShippingInstructions")], [0, 1]],
+      ["estimatedShipDate", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "EstimatedShipDate")]],
+      ["deliveryDate", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "DeliveryDate")]]
     ]
   )
 
   EncodedRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::OrderRefundHistoryResponse,
-    :schema_type => XSD::QName.new(NsOrders, "OrderRefundHistoryResponse"),
+    :class => ChannelAdvisor::OrderServiceSOAP::ArrayOfShipment,
+    :schema_type => XSD::QName.new(NsOrders, "ArrayOfShipment"),
     :schema_element => [
+      ["shipment", ["ChannelAdvisor::OrderServiceSOAP::Shipment[]", XSD::QName.new(NsOrders, "Shipment")], [0, nil]]
+    ]
+  )
+
+  EncodedRegistry.register(
+    :class => ChannelAdvisor::OrderServiceSOAP::Shipment,
+    :schema_type => XSD::QName.new(NsOrders, "Shipment"),
+    :schema_element => [
+      ["shippingCarrier", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ShippingCarrier")], [0, 1]],
+      ["shippingClass", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ShippingClass")], [0, 1]],
+      ["trackingNumber", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "TrackingNumber")], [0, 1]]
+    ]
+  )
+
+  EncodedRegistry.register(
+    :class => ChannelAdvisor::OrderServiceSOAP::ShippingInfoResponse,
+    :schema_type => XSD::QName.new(NsOrders, "ShippingInfoResponse"),
+    :schema_basetype => XSD::QName.new(NsOrders, "ShippingInfo"),
+    :schema_element => [
+      ["addressLine1", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "AddressLine1")], [0, 1]],
+      ["addressLine2", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "AddressLine2")], [0, 1]],
+      ["city", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "City")], [0, 1]],
+      ["region", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "Region")], [0, 1]],
+      ["regionDescription", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "RegionDescription")], [0, 1]],
+      ["postalCode", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "PostalCode")], [0, 1]],
+      ["countryCode", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "CountryCode")], [0, 1]],
+      ["companyName", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "CompanyName")], [0, 1]],
+      ["jobTitle", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "JobTitle")], [0, 1]],
+      ["title", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "Title")], [0, 1]],
+      ["firstName", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "FirstName")], [0, 1]],
+      ["lastName", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "LastName")], [0, 1]],
+      ["suffix", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "Suffix")], [0, 1]],
+      ["phoneNumberDay", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "PhoneNumberDay")], [0, 1]],
+      ["phoneNumberEvening", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "PhoneNumberEvening")], [0, 1]],
+      ["shipmentList", ["ChannelAdvisor::OrderServiceSOAP::ArrayOfShipment", XSD::QName.new(NsOrders, "ShipmentList")], [0, 1]],
+      ["shippingInstructions", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ShippingInstructions")], [0, 1]],
+      ["estimatedShipDate", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "EstimatedShipDate")]],
+      ["deliveryDate", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "DeliveryDate")]]
+    ]
+  )
+
+  EncodedRegistry.register(
+    :class => ChannelAdvisor::OrderServiceSOAP::OrderCriteria,
+    :schema_type => XSD::QName.new(NsOrders, "OrderCriteria"),
+    :schema_element => [
+      ["orderCreationFilterBeginTimeGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "OrderCreationFilterBeginTimeGMT")]],
+      ["orderCreationFilterEndTimeGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "OrderCreationFilterEndTimeGMT")]],
+      ["statusUpdateFilterBeginTimeGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "StatusUpdateFilterBeginTimeGMT")]],
+      ["statusUpdateFilterEndTimeGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "StatusUpdateFilterEndTimeGMT")]],
+      ["joinDateFiltersWithOr", ["SOAP::SOAPBoolean", XSD::QName.new(NsOrders, "JoinDateFiltersWithOr")]],
+      ["detailLevel", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "DetailLevel")], [0, 1]],
+      ["exportState", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ExportState")], [0, 1]],
+      ["orderIDList", ["ChannelAdvisor::OrderServiceSOAP::ArrayOfInt_", XSD::QName.new(NsOrders, "OrderIDList")], [0, 1]],
+      ["clientOrderIdentifierList", ["ChannelAdvisor::OrderServiceSOAP::ArrayOfString_", XSD::QName.new(NsOrders, "ClientOrderIdentifierList")], [0, 1]],
+      ["orderStateFilter", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "OrderStateFilter")], [0, 1]],
+      ["paymentStatusFilter", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "PaymentStatusFilter")], [0, 1]],
+      ["checkoutStatusFilter", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "CheckoutStatusFilter")], [0, 1]],
+      ["shippingStatusFilter", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ShippingStatusFilter")], [0, 1]],
+      ["refundStatusFilter", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "RefundStatusFilter")], [0, 1]],
+      ["distributionCenterCode", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "DistributionCenterCode")], [0, 1]],
+      ["fulfillmentTypeFilter", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "FulfillmentTypeFilter")], [0, 1]],
+      ["pageNumberFilter", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "PageNumberFilter")]],
+      ["pageSize", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "PageSize")]]
+    ]
+  )
+
+  EncodedRegistry.register(
+    :class => ChannelAdvisor::OrderServiceSOAP::ArrayOfInt_,
+    :schema_type => XSD::QName.new(NsOrders, "ArrayOfInt"),
+    :schema_element => [
+      ["int", "SOAP::SOAPInt[]", [0, nil]]
+    ]
+  )
+
+  EncodedRegistry.register(
+    :class => ChannelAdvisor::OrderServiceSOAP::ArrayOfString_,
+    :schema_type => XSD::QName.new(NsOrders, "ArrayOfString"),
+    :schema_element => [
+      ["string", "SOAP::SOAPString[]", [0, nil]]
+    ]
+  )
+
+  EncodedRegistry.register(
+    :class => ChannelAdvisor::OrderServiceSOAP::OrderResponseDetailLow,
+    :schema_type => XSD::QName.new(NsOrders, "OrderResponseDetailLow"),
+    :schema_basetype => XSD::QName.new(NsOrders, "OrderResponseItem"),
+    :schema_element => [
+      ["numberOfMatches", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "NumberOfMatches")]],
+      ["orderTimeGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "OrderTimeGMT")]],
+      ["lastUpdateDate", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "LastUpdateDate")]],
+      ["totalOrderAmount", ["SOAP::SOAPDecimal", XSD::QName.new(NsOrders, "TotalOrderAmount")]],
+      ["orderState", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "OrderState")], [0, 1]],
+      ["dateCancelledGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "DateCancelledGMT")]],
       ["orderID", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "OrderID")]],
       ["clientOrderIdentifier", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ClientOrderIdentifier")], [0, 1]],
-      ["refundStatus", ["ChannelAdvisor::OrderServiceSOAP::OrderRefundStatusCode", XSD::QName.new(NsOrders, "RefundStatus")]],
-      ["lineItemRefunds", ["ChannelAdvisor::OrderServiceSOAP::ArrayOfOrderLineItemRefundHistoryResponse", XSD::QName.new(NsOrders, "LineItemRefunds")], [0, 1]]
+      ["sellerOrderID", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "SellerOrderID")], [0, 1]],
+      ["flagStyle", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "FlagStyle")], [0, 1]],
+      ["orderStatus", ["ChannelAdvisor::OrderServiceSOAP::OrderStatus", XSD::QName.new(NsOrders, "OrderStatus")], [0, 1]]
     ]
   )
 
   EncodedRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::ArrayOfOrderLineItemRefundHistoryResponse,
-    :schema_type => XSD::QName.new(NsOrders, "ArrayOfOrderLineItemRefundHistoryResponse"),
+    :class => ChannelAdvisor::OrderServiceSOAP::OrderResponseDetailMedium,
+    :schema_type => XSD::QName.new(NsOrders, "OrderResponseDetailMedium"),
+    :schema_basetype => XSD::QName.new(NsOrders, "OrderResponseDetailLow"),
     :schema_element => [
-      ["orderLineItemRefundHistoryResponse", ["ChannelAdvisor::OrderServiceSOAP::OrderLineItemRefundHistoryResponse[]", XSD::QName.new(NsOrders, "OrderLineItemRefundHistoryResponse")], [0, nil]]
+      ["numberOfMatches", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "NumberOfMatches")]],
+      ["orderTimeGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "OrderTimeGMT")]],
+      ["lastUpdateDate", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "LastUpdateDate")]],
+      ["totalOrderAmount", ["SOAP::SOAPDecimal", XSD::QName.new(NsOrders, "TotalOrderAmount")]],
+      ["orderState", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "OrderState")], [0, 1]],
+      ["dateCancelledGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "DateCancelledGMT")]],
+      ["orderID", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "OrderID")]],
+      ["clientOrderIdentifier", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ClientOrderIdentifier")], [0, 1]],
+      ["sellerOrderID", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "SellerOrderID")], [0, 1]],
+      ["flagStyle", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "FlagStyle")], [0, 1]],
+      ["orderStatus", ["ChannelAdvisor::OrderServiceSOAP::OrderStatus", XSD::QName.new(NsOrders, "OrderStatus")], [0, 1]],
+      ["resellerID", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ResellerID")], [0, 1]],
+      ["buyerEmailAddress", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "BuyerEmailAddress")], [0, 1]],
+      ["emailOptIn", ["SOAP::SOAPBoolean", XSD::QName.new(NsOrders, "EmailOptIn")]],
+      ["paymentInfo", ["ChannelAdvisor::OrderServiceSOAP::PaymentInfoResponse", XSD::QName.new(NsOrders, "PaymentInfo")], [0, 1]],
+      ["shippingInfo", ["ChannelAdvisor::OrderServiceSOAP::ShippingInfoResponse", XSD::QName.new(NsOrders, "ShippingInfo")], [0, 1]],
+      ["billingInfo", ["ChannelAdvisor::OrderServiceSOAP::BillingInfo", XSD::QName.new(NsOrders, "BillingInfo")], [0, 1]],
+      ["flagDescription", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "FlagDescription")], [0, 1]]
+    ]
+  )
+
+  EncodedRegistry.register(
+    :class => ChannelAdvisor::OrderServiceSOAP::PaymentInfoResponse,
+    :schema_type => XSD::QName.new(NsOrders, "PaymentInfoResponse"),
+    :schema_basetype => XSD::QName.new(NsOrders, "PaymentInfo"),
+    :schema_element => [
+      ["paymentType", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "PaymentType")], [0, 1]],
+      ["creditCardLast4", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "CreditCardLast4")], [0, 1]],
+      ["payPalID", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "PayPalID")], [0, 1]],
+      ["merchantReferenceNumber", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "MerchantReferenceNumber")], [0, 1]],
+      ["paymentTransactionID", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "PaymentTransactionID")], [0, 1]]
+    ]
+  )
+
+  EncodedRegistry.register(
+    :class => ChannelAdvisor::OrderServiceSOAP::OrderResponseDetailHigh,
+    :schema_type => XSD::QName.new(NsOrders, "OrderResponseDetailHigh"),
+    :schema_basetype => XSD::QName.new(NsOrders, "OrderResponseDetailMedium"),
+    :schema_element => [
+      ["numberOfMatches", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "NumberOfMatches")]],
+      ["orderTimeGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "OrderTimeGMT")]],
+      ["lastUpdateDate", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "LastUpdateDate")]],
+      ["totalOrderAmount", ["SOAP::SOAPDecimal", XSD::QName.new(NsOrders, "TotalOrderAmount")]],
+      ["orderState", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "OrderState")], [0, 1]],
+      ["dateCancelledGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "DateCancelledGMT")]],
+      ["orderID", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "OrderID")]],
+      ["clientOrderIdentifier", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ClientOrderIdentifier")], [0, 1]],
+      ["sellerOrderID", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "SellerOrderID")], [0, 1]],
+      ["flagStyle", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "FlagStyle")], [0, 1]],
+      ["orderStatus", ["ChannelAdvisor::OrderServiceSOAP::OrderStatus", XSD::QName.new(NsOrders, "OrderStatus")], [0, 1]],
+      ["resellerID", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ResellerID")], [0, 1]],
+      ["buyerEmailAddress", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "BuyerEmailAddress")], [0, 1]],
+      ["emailOptIn", ["SOAP::SOAPBoolean", XSD::QName.new(NsOrders, "EmailOptIn")]],
+      ["paymentInfo", ["ChannelAdvisor::OrderServiceSOAP::PaymentInfoResponse", XSD::QName.new(NsOrders, "PaymentInfo")], [0, 1]],
+      ["shippingInfo", ["ChannelAdvisor::OrderServiceSOAP::ShippingInfoResponse", XSD::QName.new(NsOrders, "ShippingInfo")], [0, 1]],
+      ["billingInfo", ["ChannelAdvisor::OrderServiceSOAP::BillingInfo", XSD::QName.new(NsOrders, "BillingInfo")], [0, 1]],
+      ["flagDescription", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "FlagDescription")], [0, 1]],
+      ["shoppingCart", ["ChannelAdvisor::OrderServiceSOAP::OrderCart", XSD::QName.new(NsOrders, "ShoppingCart")], [0, 1]]
+    ]
+  )
+
+  EncodedRegistry.register(
+    :class => ChannelAdvisor::OrderServiceSOAP::OrderResponseDetailComplete,
+    :schema_type => XSD::QName.new(NsOrders, "OrderResponseDetailComplete"),
+    :schema_basetype => XSD::QName.new(NsOrders, "OrderResponseDetailHigh"),
+    :schema_element => [
+      ["numberOfMatches", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "NumberOfMatches")]],
+      ["orderTimeGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "OrderTimeGMT")]],
+      ["lastUpdateDate", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "LastUpdateDate")]],
+      ["totalOrderAmount", ["SOAP::SOAPDecimal", XSD::QName.new(NsOrders, "TotalOrderAmount")]],
+      ["orderState", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "OrderState")], [0, 1]],
+      ["dateCancelledGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "DateCancelledGMT")]],
+      ["orderID", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "OrderID")]],
+      ["clientOrderIdentifier", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ClientOrderIdentifier")], [0, 1]],
+      ["sellerOrderID", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "SellerOrderID")], [0, 1]],
+      ["flagStyle", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "FlagStyle")], [0, 1]],
+      ["orderStatus", ["ChannelAdvisor::OrderServiceSOAP::OrderStatus", XSD::QName.new(NsOrders, "OrderStatus")], [0, 1]],
+      ["resellerID", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ResellerID")], [0, 1]],
+      ["buyerEmailAddress", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "BuyerEmailAddress")], [0, 1]],
+      ["emailOptIn", ["SOAP::SOAPBoolean", XSD::QName.new(NsOrders, "EmailOptIn")]],
+      ["paymentInfo", ["ChannelAdvisor::OrderServiceSOAP::PaymentInfoResponse", XSD::QName.new(NsOrders, "PaymentInfo")], [0, 1]],
+      ["shippingInfo", ["ChannelAdvisor::OrderServiceSOAP::ShippingInfoResponse", XSD::QName.new(NsOrders, "ShippingInfo")], [0, 1]],
+      ["billingInfo", ["ChannelAdvisor::OrderServiceSOAP::BillingInfo", XSD::QName.new(NsOrders, "BillingInfo")], [0, 1]],
+      ["flagDescription", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "FlagDescription")], [0, 1]],
+      ["shoppingCart", ["ChannelAdvisor::OrderServiceSOAP::OrderCart", XSD::QName.new(NsOrders, "ShoppingCart")], [0, 1]],
+      ["customValueList", ["ChannelAdvisor::OrderServiceSOAP::ArrayOfCustomValue", XSD::QName.new(NsOrders, "CustomValueList")], [0, 1]],
+      ["buyerIpAddress", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "BuyerIpAddress")], [0, 1]],
+      ["transactionNotes", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "TransactionNotes")], [0, 1]]
     ]
   )
 
@@ -781,79 +942,12 @@ module DefaultMappingRegistry
     :schema_type => XSD::QName.new(NsWebservices, "ResultStatus")
   )
 
-  EncodedRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::RefundAdjustmentReason,
-    :schema_type => XSD::QName.new(NsOrders, "RefundAdjustmentReason")
-  )
-
-  EncodedRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::SiteToken,
-    :schema_type => XSD::QName.new(NsOrders, "SiteToken")
-  )
-
-  EncodedRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::AsyncStatusCode,
-    :schema_type => XSD::QName.new(NsOrders, "AsyncStatusCode")
-  )
-
-  EncodedRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::DetailLevelType,
-    :schema_type => XSD::QName.new(NsOrders, "DetailLevelType")
-  )
-
-  EncodedRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::ExportStateType,
-    :schema_type => XSD::QName.new(NsOrders, "ExportStateType")
-  )
-
-  EncodedRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::OrderStateCode,
-    :schema_type => XSD::QName.new(NsOrders, "OrderStateCode")
-  )
-
-  EncodedRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::PaymentStatusCode,
-    :schema_type => XSD::QName.new(NsOrders, "PaymentStatusCode")
-  )
-
-  EncodedRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::CheckoutStatusCode,
-    :schema_type => XSD::QName.new(NsOrders, "CheckoutStatusCode")
-  )
-
-  EncodedRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::ShippingStatusCode,
-    :schema_type => XSD::QName.new(NsOrders, "ShippingStatusCode")
-  )
-
-  EncodedRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::FlagType,
-    :schema_type => XSD::QName.new(NsOrders, "FlagType")
-  )
-
-  EncodedRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::OrderRefundStatusCode,
-    :schema_type => XSD::QName.new(NsOrders, "OrderRefundStatusCode")
-  )
-
-  EncodedRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::CheckoutSourceType,
-    :schema_type => XSD::QName.new(NsOrders, "CheckoutSourceType")
-  )
-
-  EncodedRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::VAT_Calculation_Type,
-    :schema_type => XSD::QName.new(NsOrders, "VAT_Calculation_Type")
-  )
-
-  EncodedRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::LineItemTypeCode,
-    :schema_type => XSD::QName.new(NsOrders, "LineItemTypeCode")
-  )
-
-  EncodedRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::CheckoutPaymentStatusCode,
-    :schema_type => XSD::QName.new(NsOrders, "CheckoutPaymentStatusCode")
+  LiteralRegistry.register(
+    :class => ChannelAdvisor::OrderServiceSOAP::ArrayOfInt,
+    :schema_type => XSD::QName.new(NsWebservices, "ArrayOfInt"),
+    :schema_element => [
+      ["int", "SOAP::SOAPInt[]", [0, nil]]
+    ]
   )
 
   LiteralRegistry.register(
@@ -865,22 +959,32 @@ module DefaultMappingRegistry
   )
 
   LiteralRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::APIResultOfArrayOfBoolean,
-    :schema_type => XSD::QName.new(NsWebservices, "APIResultOfArrayOfBoolean"),
+    :class => ChannelAdvisor::OrderServiceSOAP::APIResultOfArrayOfSetExportStatusResponse,
+    :schema_type => XSD::QName.new(NsWebservices, "APIResultOfArrayOfSetExportStatusResponse"),
     :schema_element => [
       ["status", ["ChannelAdvisor::OrderServiceSOAP::ResultStatus", XSD::QName.new(NsWebservices, "Status")]],
       ["messageCode", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "MessageCode")]],
       ["message", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Message")], [0, 1]],
       ["data", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Data")], [0, 1]],
-      ["resultData", ["ChannelAdvisor::OrderServiceSOAP::ArrayOfBoolean", XSD::QName.new(NsWebservices, "ResultData")], [0, 1]]
+      ["resultData", ["ChannelAdvisor::OrderServiceSOAP::ArrayOfSetExportStatusResponse", XSD::QName.new(NsWebservices, "ResultData")], [0, 1]]
     ]
   )
 
   LiteralRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::ArrayOfBoolean,
-    :schema_type => XSD::QName.new(NsWebservices, "ArrayOfBoolean"),
+    :class => ChannelAdvisor::OrderServiceSOAP::ArrayOfSetExportStatusResponse,
+    :schema_type => XSD::QName.new(NsWebservices, "ArrayOfSetExportStatusResponse"),
     :schema_element => [
-      ["boolean", "SOAP::SOAPBoolean[]", [0, nil]]
+      ["setExportStatusResponse", ["ChannelAdvisor::OrderServiceSOAP::SetExportStatusResponse[]", XSD::QName.new(NsWebservices, "SetExportStatusResponse")], [0, nil]]
+    ]
+  )
+
+  LiteralRegistry.register(
+    :class => ChannelAdvisor::OrderServiceSOAP::SetExportStatusResponse,
+    :schema_type => XSD::QName.new(NsWebservices, "SetExportStatusResponse"),
+    :schema_element => [
+      ["orderID", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "OrderID")]],
+      ["clientOrderIdentifier", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "ClientOrderIdentifier")], [0, 1]],
+      ["success", ["SOAP::SOAPBoolean", XSD::QName.new(NsWebservices, "Success")]]
     ]
   )
 
@@ -906,46 +1010,6 @@ module DefaultMappingRegistry
   )
 
   LiteralRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::APIResultOfArrayOfOrderResponseItem,
-    :schema_type => XSD::QName.new(NsWebservices, "APIResultOfArrayOfOrderResponseItem"),
-    :schema_element => [
-      ["status", ["ChannelAdvisor::OrderServiceSOAP::ResultStatus", XSD::QName.new(NsWebservices, "Status")]],
-      ["messageCode", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "MessageCode")]],
-      ["message", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Message")], [0, 1]],
-      ["data", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Data")], [0, 1]],
-      ["resultData", ["ChannelAdvisor::OrderServiceSOAP::ArrayOfOrderResponseItem", XSD::QName.new(NsWebservices, "ResultData")], [0, 1]]
-    ]
-  )
-
-  LiteralRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::ArrayOfOrderResponseItem,
-    :schema_type => XSD::QName.new(NsWebservices, "ArrayOfOrderResponseItem"),
-    :schema_element => [
-      ["orderResponseItem", ["ChannelAdvisor::OrderServiceSOAP::OrderResponseItem[]", XSD::QName.new(NsWebservices, "OrderResponseItem")], [0, nil]]
-    ]
-  )
-
-  LiteralRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::APIResultOfInt32,
-    :schema_type => XSD::QName.new(NsWebservices, "APIResultOfInt32"),
-    :schema_element => [
-      ["status", ["ChannelAdvisor::OrderServiceSOAP::ResultStatus", XSD::QName.new(NsWebservices, "Status")]],
-      ["messageCode", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "MessageCode")]],
-      ["message", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Message")], [0, 1]],
-      ["data", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Data")], [0, 1]],
-      ["resultData", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "ResultData")]]
-    ]
-  )
-
-  LiteralRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::ArrayOfInt,
-    :schema_type => XSD::QName.new(NsWebservices, "ArrayOfInt"),
-    :schema_element => [
-      ["int", "SOAP::SOAPInt[]", [0, nil]]
-    ]
-  )
-
-  LiteralRegistry.register(
     :class => ChannelAdvisor::OrderServiceSOAP::APIResultOfArrayOfInt32,
     :schema_type => XSD::QName.new(NsWebservices, "APIResultOfArrayOfInt32"),
     :schema_element => [
@@ -954,6 +1018,26 @@ module DefaultMappingRegistry
       ["message", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Message")], [0, 1]],
       ["data", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Data")], [0, 1]],
       ["resultData", ["ChannelAdvisor::OrderServiceSOAP::ArrayOfInt", XSD::QName.new(NsWebservices, "ResultData")], [0, 1]]
+    ]
+  )
+
+  LiteralRegistry.register(
+    :class => ChannelAdvisor::OrderServiceSOAP::APIResultOfArrayOfBoolean,
+    :schema_type => XSD::QName.new(NsWebservices, "APIResultOfArrayOfBoolean"),
+    :schema_element => [
+      ["status", ["ChannelAdvisor::OrderServiceSOAP::ResultStatus", XSD::QName.new(NsWebservices, "Status")]],
+      ["messageCode", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "MessageCode")]],
+      ["message", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Message")], [0, 1]],
+      ["data", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Data")], [0, 1]],
+      ["resultData", ["ChannelAdvisor::OrderServiceSOAP::ArrayOfBoolean", XSD::QName.new(NsWebservices, "ResultData")], [0, 1]]
+    ]
+  )
+
+  LiteralRegistry.register(
+    :class => ChannelAdvisor::OrderServiceSOAP::ArrayOfBoolean,
+    :schema_type => XSD::QName.new(NsWebservices, "ArrayOfBoolean"),
+    :schema_element => [
+      ["boolean", "SOAP::SOAPBoolean[]", [0, nil]]
     ]
   )
 
@@ -982,10 +1066,15 @@ module DefaultMappingRegistry
     :schema_type => XSD::QName.new(NsWebservices, "OrderUpdateSubmit"),
     :schema_element => [
       ["orderID", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "OrderID")]],
-      ["flagStyle", ["ChannelAdvisor::OrderServiceSOAP::FlagType", XSD::QName.new(NsWebservices, "FlagStyle")]],
+      ["newClientOrderIdentifier", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "NewClientOrderIdentifier")], [0, 1]],
+      ["flagStyle", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "FlagStyle")], [0, 1]],
       ["flagDescription", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "FlagDescription")], [0, 1]],
       ["transactionNotes", ["ChannelAdvisor::OrderServiceSOAP::TransactionNoteSubmit", XSD::QName.new(NsWebservices, "TransactionNotes")], [0, 1]],
-      ["orderStatusUpdate", ["ChannelAdvisor::OrderServiceSOAP::OrderStatusUpdateSubmit", XSD::QName.new(NsWebservices, "OrderStatusUpdate")], [0, 1]]
+      ["orderStatusUpdate", ["ChannelAdvisor::OrderServiceSOAP::OrderStatusUpdateSubmit", XSD::QName.new(NsWebservices, "OrderStatusUpdate")], [0, 1]],
+      ["billingInfo", ["ChannelAdvisor::OrderServiceSOAP::BillingInfoUpdateSubmit", XSD::QName.new(NsWebservices, "BillingInfo")], [0, 1]],
+      ["shippingInfo", ["ChannelAdvisor::OrderServiceSOAP::ShippingInfoUpdateSubmit", XSD::QName.new(NsWebservices, "ShippingInfo")], [0, 1]],
+      ["paymentInfo", ["ChannelAdvisor::OrderServiceSOAP::PaymentInfoUpdateSubmit", XSD::QName.new(NsWebservices, "PaymentInfo")], [0, 1]],
+      ["requestedShippingMethodInfo", ["ChannelAdvisor::OrderServiceSOAP::ShippingMethodInfoUpdateSubmit", XSD::QName.new(NsWebservices, "RequestedShippingMethodInfo")], [0, 1]]
     ]
   )
 
@@ -1002,8 +1091,17 @@ module DefaultMappingRegistry
     :class => ChannelAdvisor::OrderServiceSOAP::OrderStatusUpdateSubmit,
     :schema_type => XSD::QName.new(NsWebservices, "OrderStatusUpdateSubmit"),
     :schema_element => [
-      ["checkoutPaymentStatus", ["ChannelAdvisor::OrderServiceSOAP::CheckoutPaymentStatusCode", XSD::QName.new(NsWebservices, "CheckoutPaymentStatus")]],
-      ["shippingStatus", ["ChannelAdvisor::OrderServiceSOAP::ShippingStatusCode", XSD::QName.new(NsWebservices, "ShippingStatus")]]
+      ["checkoutPaymentStatus", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "CheckoutPaymentStatus")], [0, 1]],
+      ["shippingStatus", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "ShippingStatus")], [0, 1]]
+    ]
+  )
+
+  LiteralRegistry.register(
+    :class => ChannelAdvisor::OrderServiceSOAP::ShippingMethodInfoUpdateSubmit,
+    :schema_type => XSD::QName.new(NsWebservices, "ShippingMethodInfoUpdateSubmit"),
+    :schema_element => [
+      ["carrierCode", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "CarrierCode")], [0, 1]],
+      ["classCode", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "ClassCode")], [0, 1]]
     ]
   )
 
@@ -1034,7 +1132,57 @@ module DefaultMappingRegistry
       ["flagAndNotesSuccess", ["SOAP::SOAPBoolean", XSD::QName.new(NsWebservices, "FlagAndNotesSuccess")]],
       ["flagAndNotesMessage", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "FlagAndNotesMessage")], [0, 1]],
       ["orderStatusSuccess", ["SOAP::SOAPBoolean", XSD::QName.new(NsWebservices, "OrderStatusSuccess")]],
-      ["orderStatusMessage", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "OrderStatusMessage")], [0, 1]]
+      ["orderStatusMessage", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "OrderStatusMessage")], [0, 1]],
+      ["shippingAndCOIDSuccess", ["SOAP::SOAPBoolean", XSD::QName.new(NsWebservices, "ShippingAndCOIDSuccess")]],
+      ["shippingAndCOIDMessage", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "ShippingAndCOIDMessage")], [0, 1]],
+      ["billingAndPaymentSuccess", ["SOAP::SOAPBoolean", XSD::QName.new(NsWebservices, "BillingAndPaymentSuccess")]],
+      ["billingAndPaymentMessage", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "BillingAndPaymentMessage")], [0, 1]],
+      ["requestedShippingMethodSuccess", ["SOAP::SOAPBoolean", XSD::QName.new(NsWebservices, "RequestedShippingMethodSuccess")]],
+      ["requestedShippingMethodMessage", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "RequestedShippingMethodMessage")], [0, 1]]
+    ]
+  )
+
+  LiteralRegistry.register(
+    :class => ChannelAdvisor::OrderServiceSOAP::APIResultOfBoolean,
+    :schema_type => XSD::QName.new(NsWebservices, "APIResultOfBoolean"),
+    :schema_element => [
+      ["status", ["ChannelAdvisor::OrderServiceSOAP::ResultStatus", XSD::QName.new(NsWebservices, "Status")]],
+      ["messageCode", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "MessageCode")]],
+      ["message", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Message")], [0, 1]],
+      ["data", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Data")], [0, 1]],
+      ["resultData", ["SOAP::SOAPBoolean", XSD::QName.new(NsWebservices, "ResultData")]]
+    ]
+  )
+
+  LiteralRegistry.register(
+    :class => ChannelAdvisor::OrderServiceSOAP::APIResultOfInt32,
+    :schema_type => XSD::QName.new(NsWebservices, "APIResultOfInt32"),
+    :schema_element => [
+      ["status", ["ChannelAdvisor::OrderServiceSOAP::ResultStatus", XSD::QName.new(NsWebservices, "Status")]],
+      ["messageCode", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "MessageCode")]],
+      ["message", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Message")], [0, 1]],
+      ["data", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Data")], [0, 1]],
+      ["resultData", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "ResultData")]]
+    ]
+  )
+
+  LiteralRegistry.register(
+    :class => ChannelAdvisor::OrderServiceSOAP::APIResultOfArrayOfOrderResponseItem,
+    :schema_type => XSD::QName.new(NsWebservices, "APIResultOfArrayOfOrderResponseItem"),
+    :schema_element => [
+      ["status", ["ChannelAdvisor::OrderServiceSOAP::ResultStatus", XSD::QName.new(NsWebservices, "Status")]],
+      ["messageCode", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "MessageCode")]],
+      ["message", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Message")], [0, 1]],
+      ["data", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Data")], [0, 1]],
+      ["resultData", ["ChannelAdvisor::OrderServiceSOAP::ArrayOfOrderResponseItem", XSD::QName.new(NsWebservices, "ResultData")], [0, 1]]
+    ]
+  )
+
+  LiteralRegistry.register(
+    :class => ChannelAdvisor::OrderServiceSOAP::ArrayOfOrderResponseItem,
+    :schema_type => XSD::QName.new(NsWebservices, "ArrayOfOrderResponseItem"),
+    :schema_element => [
+      ["orderResponseItem", ["ChannelAdvisor::OrderServiceSOAP::OrderResponseItem[]", XSD::QName.new(NsWebservices, "OrderResponseItem")], [0, nil]]
     ]
   )
 
@@ -1057,7 +1205,7 @@ module DefaultMappingRegistry
       ["clientOrderIdentifier", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ClientOrderIdentifier")], [0, 1]],
       ["orderID", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "OrderID")]],
       ["amount", ["SOAP::SOAPDecimal", XSD::QName.new(NsOrders, "Amount")]],
-      ["adjustmentReason", ["ChannelAdvisor::OrderServiceSOAP::RefundAdjustmentReason", XSD::QName.new(NsOrders, "AdjustmentReason")]],
+      ["adjustmentReason", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "AdjustmentReason")], [0, 1]],
       ["sellerRefundID", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "SellerRefundID")], [0, 1]],
       ["refundItems", ["ChannelAdvisor::OrderServiceSOAP::ArrayOfRefundItem", XSD::QName.new(NsOrders, "RefundItems")], [0, 1]]
     ]
@@ -1082,12 +1230,14 @@ module DefaultMappingRegistry
       ["taxAmount", ["SOAP::SOAPDecimal", XSD::QName.new(NsOrders, "TaxAmount")]],
       ["giftWrapAmount", ["SOAP::SOAPDecimal", XSD::QName.new(NsOrders, "GiftWrapAmount")]],
       ["giftWrapTaxAmount", ["SOAP::SOAPDecimal", XSD::QName.new(NsOrders, "GiftWrapTaxAmount")]],
+      ["recyclingFee", ["SOAP::SOAPDecimal", XSD::QName.new(NsOrders, "RecyclingFee")]],
       ["quantity", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "Quantity")]],
       ["refundRequestID", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "RefundRequestID")]],
       ["refundRequested", ["SOAP::SOAPBoolean", XSD::QName.new(NsOrders, "RefundRequested")]],
       ["restockQuantity", ["SOAP::SOAPBoolean", XSD::QName.new(NsOrders, "RestockQuantity")]],
-      ["adjustmentReason", ["ChannelAdvisor::OrderServiceSOAP::RefundAdjustmentReason", XSD::QName.new(NsOrders, "AdjustmentReason")]],
-      ["sellerRefundID", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "SellerRefundID")], [0, 1]]
+      ["adjustmentReason", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "AdjustmentReason")], [0, 1]],
+      ["sellerRefundID", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "SellerRefundID")], [0, 1]],
+      ["lineItemID", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "LineItemID")]]
     ]
   )
 
@@ -1103,17 +1253,19 @@ module DefaultMappingRegistry
       ["taxAmount", ["SOAP::SOAPDecimal", XSD::QName.new(NsOrders, "TaxAmount")]],
       ["giftWrapAmount", ["SOAP::SOAPDecimal", XSD::QName.new(NsOrders, "GiftWrapAmount")]],
       ["giftWrapTaxAmount", ["SOAP::SOAPDecimal", XSD::QName.new(NsOrders, "GiftWrapTaxAmount")]],
+      ["recyclingFee", ["SOAP::SOAPDecimal", XSD::QName.new(NsOrders, "RecyclingFee")]],
       ["quantity", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "Quantity")]],
       ["refundRequestID", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "RefundRequestID")]],
       ["refundRequested", ["SOAP::SOAPBoolean", XSD::QName.new(NsOrders, "RefundRequested")]],
       ["restockQuantity", ["SOAP::SOAPBoolean", XSD::QName.new(NsOrders, "RestockQuantity")]],
-      ["adjustmentReason", ["ChannelAdvisor::OrderServiceSOAP::RefundAdjustmentReason", XSD::QName.new(NsOrders, "AdjustmentReason")]],
+      ["adjustmentReason", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "AdjustmentReason")], [0, 1]],
       ["sellerRefundID", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "SellerRefundID")], [0, 1]],
+      ["lineItemID", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "LineItemID")]],
       ["invoiceItemID", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "InvoiceItemID")]],
-      ["itemSaleSource", ["ChannelAdvisor::OrderServiceSOAP::SiteToken", XSD::QName.new(NsOrders, "ItemSaleSource")]],
-      ["refundRequestStatus", ["ChannelAdvisor::OrderServiceSOAP::AsyncStatusCode", XSD::QName.new(NsOrders, "RefundRequestStatus")]],
+      ["itemSaleSource", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ItemSaleSource")], [0, 1]],
+      ["refundRequestStatus", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "RefundRequestStatus")], [0, 1]],
       ["refundPaymentInfo", ["ChannelAdvisor::OrderServiceSOAP::PaymentInfo", XSD::QName.new(NsOrders, "RefundPaymentInfo")], [0, 1]],
-      ["restockStatus", ["ChannelAdvisor::OrderServiceSOAP::AsyncStatusCode", XSD::QName.new(NsOrders, "RestockStatus")]],
+      ["restockStatus", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "RestockStatus")], [0, 1]],
       ["refundCreateDateGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "RefundCreateDateGMT")]]
     ]
   )
@@ -1143,114 +1295,34 @@ module DefaultMappingRegistry
   )
 
   LiteralRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::OrderCriteria,
-    :schema_type => XSD::QName.new(NsOrders, "OrderCriteria"),
+    :class => ChannelAdvisor::OrderServiceSOAP::OrderRefundHistoryResponse,
+    :schema_type => XSD::QName.new(NsOrders, "OrderRefundHistoryResponse"),
     :schema_element => [
-      ["orderCreationFilterBeginTimeGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "OrderCreationFilterBeginTimeGMT")]],
-      ["orderCreationFilterEndTimeGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "OrderCreationFilterEndTimeGMT")]],
-      ["statusUpdateFilterBeginTimeGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "StatusUpdateFilterBeginTimeGMT")]],
-      ["statusUpdateFilterEndTimeGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "StatusUpdateFilterEndTimeGMT")]],
-      ["joinDateFiltersWithOr", ["SOAP::SOAPBoolean", XSD::QName.new(NsOrders, "JoinDateFiltersWithOr")]],
-      ["detailLevel", ["ChannelAdvisor::OrderServiceSOAP::DetailLevelType", XSD::QName.new(NsOrders, "DetailLevel")]],
-      ["exportState", ["ChannelAdvisor::OrderServiceSOAP::ExportStateType", XSD::QName.new(NsOrders, "ExportState")]],
-      ["orderIDList", ["ChannelAdvisor::OrderServiceSOAP::ArrayOfInt_", XSD::QName.new(NsOrders, "OrderIDList")], [0, 1]],
-      ["orderStateFilter", ["ChannelAdvisor::OrderServiceSOAP::OrderStateCode", XSD::QName.new(NsOrders, "OrderStateFilter")]],
-      ["paymentStatusFilter", ["ChannelAdvisor::OrderServiceSOAP::PaymentStatusCode", XSD::QName.new(NsOrders, "PaymentStatusFilter")]],
-      ["checkoutStatusFilter", ["ChannelAdvisor::OrderServiceSOAP::CheckoutStatusCode", XSD::QName.new(NsOrders, "CheckoutStatusFilter")]],
-      ["shippingStatusFilter", ["ChannelAdvisor::OrderServiceSOAP::ShippingStatusCode", XSD::QName.new(NsOrders, "ShippingStatusFilter")]],
-      ["distributionCenterCode", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "DistributionCenterCode")], [0, 1]],
-      ["pageNumberFilter", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "PageNumberFilter")]],
-      ["pageSize", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "PageSize")]]
-    ]
-  )
-
-  LiteralRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::ArrayOfInt_,
-    :schema_type => XSD::QName.new(NsOrders, "ArrayOfInt"),
-    :schema_element => [
-      ["int", "SOAP::SOAPInt[]", [0, nil]]
-    ]
-  )
-
-  LiteralRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::OrderResponseDetailLow,
-    :schema_type => XSD::QName.new(NsOrders, "OrderResponseDetailLow"),
-    :schema_basetype => XSD::QName.new(NsOrders, "OrderResponseItem"),
-    :schema_element => [
-      ["numberOfMatches", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "NumberOfMatches")]],
-      ["orderTimeGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "OrderTimeGMT")]],
-      ["lastUpdateDate", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "LastUpdateDate")]],
-      ["totalOrderAmount", ["SOAP::SOAPDecimal", XSD::QName.new(NsOrders, "TotalOrderAmount")]],
-      ["orderState", ["ChannelAdvisor::OrderServiceSOAP::OrderStateCode", XSD::QName.new(NsOrders, "OrderState")]],
-      ["dateCancelledGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "DateCancelledGMT")]],
       ["orderID", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "OrderID")]],
       ["clientOrderIdentifier", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ClientOrderIdentifier")], [0, 1]],
-      ["flagStyle", ["ChannelAdvisor::OrderServiceSOAP::FlagType", XSD::QName.new(NsOrders, "FlagStyle")]],
-      ["orderStatus", ["ChannelAdvisor::OrderServiceSOAP::OrderStatus", XSD::QName.new(NsOrders, "OrderStatus")], [0, 1]]
+      ["refundStatus", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "RefundStatus")], [0, 1]],
+      ["lineItemRefunds", ["ChannelAdvisor::OrderServiceSOAP::ArrayOfOrderLineItemRefundHistoryResponse", XSD::QName.new(NsOrders, "LineItemRefunds")], [0, 1]]
     ]
   )
 
   LiteralRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::OrderStatus,
-    :schema_type => XSD::QName.new(NsOrders, "OrderStatus"),
+    :class => ChannelAdvisor::OrderServiceSOAP::ArrayOfOrderLineItemRefundHistoryResponse,
+    :schema_type => XSD::QName.new(NsOrders, "ArrayOfOrderLineItemRefundHistoryResponse"),
     :schema_element => [
-      ["checkoutStatus", ["ChannelAdvisor::OrderServiceSOAP::CheckoutStatusCode", XSD::QName.new(NsOrders, "CheckoutStatus")]],
-      ["checkoutDateGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "CheckoutDateGMT")]],
-      ["paymentStatus", ["ChannelAdvisor::OrderServiceSOAP::PaymentStatusCode", XSD::QName.new(NsOrders, "PaymentStatus")]],
-      ["paymentDateGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "PaymentDateGMT")]],
-      ["shippingStatus", ["ChannelAdvisor::OrderServiceSOAP::ShippingStatusCode", XSD::QName.new(NsOrders, "ShippingStatus")]],
-      ["shippingDateGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "ShippingDateGMT")]],
-      ["orderRefundStatus", ["ChannelAdvisor::OrderServiceSOAP::OrderRefundStatusCode", XSD::QName.new(NsOrders, "OrderRefundStatus")]]
+      ["orderLineItemRefundHistoryResponse", ["ChannelAdvisor::OrderServiceSOAP::OrderLineItemRefundHistoryResponse[]", XSD::QName.new(NsOrders, "OrderLineItemRefundHistoryResponse")], [0, nil]]
     ]
   )
 
   LiteralRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::OrderResponseDetailMedium,
-    :schema_type => XSD::QName.new(NsOrders, "OrderResponseDetailMedium"),
-    :schema_basetype => XSD::QName.new(NsOrders, "OrderResponseDetailLow"),
-    :schema_element => [
-      ["numberOfMatches", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "NumberOfMatches")]],
-      ["orderTimeGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "OrderTimeGMT")]],
-      ["lastUpdateDate", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "LastUpdateDate")]],
-      ["totalOrderAmount", ["SOAP::SOAPDecimal", XSD::QName.new(NsOrders, "TotalOrderAmount")]],
-      ["orderState", ["ChannelAdvisor::OrderServiceSOAP::OrderStateCode", XSD::QName.new(NsOrders, "OrderState")]],
-      ["dateCancelledGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "DateCancelledGMT")]],
-      ["orderID", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "OrderID")]],
-      ["clientOrderIdentifier", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ClientOrderIdentifier")], [0, 1]],
-      ["flagStyle", ["ChannelAdvisor::OrderServiceSOAP::FlagType", XSD::QName.new(NsOrders, "FlagStyle")]],
-      ["orderStatus", ["ChannelAdvisor::OrderServiceSOAP::OrderStatus", XSD::QName.new(NsOrders, "OrderStatus")], [0, 1]],
-      ["resellerID", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ResellerID")], [0, 1]],
-      ["buyerEmailAddress", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "BuyerEmailAddress")], [0, 1]],
-      ["emailOptIn", ["SOAP::SOAPBoolean", XSD::QName.new(NsOrders, "EmailOptIn")]],
-      ["paymentInfo", ["ChannelAdvisor::OrderServiceSOAP::PaymentInfoResponse", XSD::QName.new(NsOrders, "PaymentInfo")], [0, 1]],
-      ["shippingInfo", ["ChannelAdvisor::OrderServiceSOAP::ShippingInfoResponse", XSD::QName.new(NsOrders, "ShippingInfo")], [0, 1]],
-      ["billingInfo", ["ChannelAdvisor::OrderServiceSOAP::BillingInfo", XSD::QName.new(NsOrders, "BillingInfo")], [0, 1]],
-      ["flagDescription", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "FlagDescription")], [0, 1]]
-    ]
-  )
-
-  LiteralRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::PaymentInfoResponse,
-    :schema_type => XSD::QName.new(NsOrders, "PaymentInfoResponse"),
-    :schema_basetype => XSD::QName.new(NsOrders, "PaymentInfo"),
-    :schema_element => [
-      ["paymentType", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "PaymentType")], [0, 1]],
-      ["creditCardLast4", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "CreditCardLast4")], [0, 1]],
-      ["payPalID", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "PayPalID")], [0, 1]],
-      ["merchantReferenceNumber", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "MerchantReferenceNumber")], [0, 1]],
-      ["paymentTransactionID", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "PaymentTransactionID")], [0, 1]]
-    ]
-  )
-
-  LiteralRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::ShippingInfoResponse,
-    :schema_type => XSD::QName.new(NsOrders, "ShippingInfoResponse"),
-    :schema_basetype => XSD::QName.new(NsOrders, "ShippingInfo"),
+    :class => ChannelAdvisor::OrderServiceSOAP::BillingInfoUpdateSubmit,
+    :schema_type => XSD::QName.new(NsOrders, "BillingInfoUpdateSubmit"),
+    :schema_basetype => XSD::QName.new(NsOrders, "BillingInfo"),
     :schema_element => [
       ["addressLine1", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "AddressLine1")], [0, 1]],
       ["addressLine2", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "AddressLine2")], [0, 1]],
       ["city", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "City")], [0, 1]],
       ["region", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "Region")], [0, 1]],
+      ["regionDescription", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "RegionDescription")], [0, 1]],
       ["postalCode", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "PostalCode")], [0, 1]],
       ["countryCode", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "CountryCode")], [0, 1]],
       ["companyName", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "CompanyName")], [0, 1]],
@@ -1261,8 +1333,30 @@ module DefaultMappingRegistry
       ["suffix", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "Suffix")], [0, 1]],
       ["phoneNumberDay", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "PhoneNumberDay")], [0, 1]],
       ["phoneNumberEvening", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "PhoneNumberEvening")], [0, 1]],
-      ["shipmentList", ["ChannelAdvisor::OrderServiceSOAP::ArrayOfShipment", XSD::QName.new(NsOrders, "ShipmentList")], [0, 1]],
-      ["shippingInstructions", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ShippingInstructions")], [0, 1]]
+      ["emailAddress", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "EmailAddress")], [0, 1]]
+    ]
+  )
+
+  LiteralRegistry.register(
+    :class => ChannelAdvisor::OrderServiceSOAP::BillingInfo,
+    :schema_type => XSD::QName.new(NsOrders, "BillingInfo"),
+    :schema_basetype => XSD::QName.new(NsOrders, "ContactComplete"),
+    :schema_element => [
+      ["addressLine1", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "AddressLine1")], [0, 1]],
+      ["addressLine2", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "AddressLine2")], [0, 1]],
+      ["city", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "City")], [0, 1]],
+      ["region", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "Region")], [0, 1]],
+      ["regionDescription", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "RegionDescription")], [0, 1]],
+      ["postalCode", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "PostalCode")], [0, 1]],
+      ["countryCode", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "CountryCode")], [0, 1]],
+      ["companyName", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "CompanyName")], [0, 1]],
+      ["jobTitle", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "JobTitle")], [0, 1]],
+      ["title", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "Title")], [0, 1]],
+      ["firstName", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "FirstName")], [0, 1]],
+      ["lastName", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "LastName")], [0, 1]],
+      ["suffix", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "Suffix")], [0, 1]],
+      ["phoneNumberDay", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "PhoneNumberDay")], [0, 1]],
+      ["phoneNumberEvening", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "PhoneNumberEvening")], [0, 1]]
     ]
   )
 
@@ -1275,6 +1369,7 @@ module DefaultMappingRegistry
       ["addressLine2", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "AddressLine2")], [0, 1]],
       ["city", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "City")], [0, 1]],
       ["region", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "Region")], [0, 1]],
+      ["regionDescription", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "RegionDescription")], [0, 1]],
       ["postalCode", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "PostalCode")], [0, 1]],
       ["countryCode", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "CountryCode")], [0, 1]],
       ["companyName", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "CompanyName")], [0, 1]],
@@ -1296,20 +1391,22 @@ module DefaultMappingRegistry
       ["addressLine2", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "AddressLine2")], [0, 1]],
       ["city", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "City")], [0, 1]],
       ["region", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "Region")], [0, 1]],
+      ["regionDescription", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "RegionDescription")], [0, 1]],
       ["postalCode", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "PostalCode")], [0, 1]],
       ["countryCode", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "CountryCode")], [0, 1]]
     ]
   )
 
   LiteralRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::BillingInfo,
-    :schema_type => XSD::QName.new(NsOrders, "BillingInfo"),
+    :class => ChannelAdvisor::OrderServiceSOAP::ShippingInfoUpdateSubmit,
+    :schema_type => XSD::QName.new(NsOrders, "ShippingInfoUpdateSubmit"),
     :schema_basetype => XSD::QName.new(NsOrders, "ContactComplete"),
     :schema_element => [
       ["addressLine1", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "AddressLine1")], [0, 1]],
       ["addressLine2", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "AddressLine2")], [0, 1]],
       ["city", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "City")], [0, 1]],
       ["region", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "Region")], [0, 1]],
+      ["regionDescription", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "RegionDescription")], [0, 1]],
       ["postalCode", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "PostalCode")], [0, 1]],
       ["countryCode", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "CountryCode")], [0, 1]],
       ["companyName", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "CompanyName")], [0, 1]],
@@ -1319,51 +1416,58 @@ module DefaultMappingRegistry
       ["lastName", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "LastName")], [0, 1]],
       ["suffix", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "Suffix")], [0, 1]],
       ["phoneNumberDay", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "PhoneNumberDay")], [0, 1]],
-      ["phoneNumberEvening", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "PhoneNumberEvening")], [0, 1]]
+      ["phoneNumberEvening", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "PhoneNumberEvening")], [0, 1]],
+      ["emailAddress", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "EmailAddress")], [0, 1]],
+      ["shippingInstructions", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ShippingInstructions")], [0, 1]],
+      ["estimatedShipDate", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "EstimatedShipDate")]],
+      ["deliveryDate", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "DeliveryDate")]]
     ]
   )
 
   LiteralRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::ArrayOfShipment,
-    :schema_type => XSD::QName.new(NsOrders, "ArrayOfShipment"),
+    :class => ChannelAdvisor::OrderServiceSOAP::PaymentInfoUpdateSubmit,
+    :schema_type => XSD::QName.new(NsOrders, "PaymentInfoUpdateSubmit"),
+    :schema_basetype => XSD::QName.new(NsOrders, "PaymentInfo"),
     :schema_element => [
-      ["shipment", ["ChannelAdvisor::OrderServiceSOAP::Shipment[]", XSD::QName.new(NsOrders, "Shipment")], [0, nil]]
+      ["paymentType", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "PaymentType")], [0, 1]],
+      ["creditCardLast4", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "CreditCardLast4")], [0, 1]],
+      ["payPalID", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "PayPalID")], [0, 1]],
+      ["merchantReferenceNumber", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "MerchantReferenceNumber")], [0, 1]],
+      ["paymentTransactionID", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "PaymentTransactionID")], [0, 1]]
     ]
   )
 
   LiteralRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::Shipment,
-    :schema_type => XSD::QName.new(NsOrders, "Shipment"),
+    :class => ChannelAdvisor::OrderServiceSOAP::OrderSubmit,
+    :schema_type => XSD::QName.new(NsOrders, "OrderSubmit"),
+    :schema_basetype => XSD::QName.new(NsOrders, "Order"),
     :schema_element => [
-      ["shippingCarrier", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ShippingCarrier")], [0, 1]],
-      ["shippingClass", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ShippingClass")], [0, 1]],
-      ["trackingNumber", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "TrackingNumber")], [0, 1]]
-    ]
-  )
-
-  LiteralRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::OrderResponseDetailHigh,
-    :schema_type => XSD::QName.new(NsOrders, "OrderResponseDetailHigh"),
-    :schema_basetype => XSD::QName.new(NsOrders, "OrderResponseDetailMedium"),
-    :schema_element => [
-      ["numberOfMatches", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "NumberOfMatches")]],
       ["orderTimeGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "OrderTimeGMT")]],
-      ["lastUpdateDate", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "LastUpdateDate")]],
-      ["totalOrderAmount", ["SOAP::SOAPDecimal", XSD::QName.new(NsOrders, "TotalOrderAmount")]],
-      ["orderState", ["ChannelAdvisor::OrderServiceSOAP::OrderStateCode", XSD::QName.new(NsOrders, "OrderState")]],
-      ["dateCancelledGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "DateCancelledGMT")]],
-      ["orderID", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "OrderID")]],
       ["clientOrderIdentifier", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ClientOrderIdentifier")], [0, 1]],
-      ["flagStyle", ["ChannelAdvisor::OrderServiceSOAP::FlagType", XSD::QName.new(NsOrders, "FlagStyle")]],
+      ["sellerOrderID", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "SellerOrderID")], [0, 1]],
       ["orderStatus", ["ChannelAdvisor::OrderServiceSOAP::OrderStatus", XSD::QName.new(NsOrders, "OrderStatus")], [0, 1]],
-      ["resellerID", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ResellerID")], [0, 1]],
       ["buyerEmailAddress", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "BuyerEmailAddress")], [0, 1]],
       ["emailOptIn", ["SOAP::SOAPBoolean", XSD::QName.new(NsOrders, "EmailOptIn")]],
-      ["paymentInfo", ["ChannelAdvisor::OrderServiceSOAP::PaymentInfoResponse", XSD::QName.new(NsOrders, "PaymentInfo")], [0, 1]],
-      ["shippingInfo", ["ChannelAdvisor::OrderServiceSOAP::ShippingInfoResponse", XSD::QName.new(NsOrders, "ShippingInfo")], [0, 1]],
+      ["resellerID", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ResellerID")], [0, 1]],
       ["billingInfo", ["ChannelAdvisor::OrderServiceSOAP::BillingInfo", XSD::QName.new(NsOrders, "BillingInfo")], [0, 1]],
-      ["flagDescription", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "FlagDescription")], [0, 1]],
-      ["shoppingCart", ["ChannelAdvisor::OrderServiceSOAP::OrderCart", XSD::QName.new(NsOrders, "ShoppingCart")], [0, 1]]
+      ["paymentInfo", ["ChannelAdvisor::OrderServiceSOAP::PaymentInfo", XSD::QName.new(NsOrders, "PaymentInfo")], [0, 1]],
+      ["shoppingCart", ["ChannelAdvisor::OrderServiceSOAP::OrderCart", XSD::QName.new(NsOrders, "ShoppingCart")], [0, 1]],
+      ["customValueList", ["ChannelAdvisor::OrderServiceSOAP::ArrayOfCustomValue", XSD::QName.new(NsOrders, "CustomValueList")], [0, 1]],
+      ["shippingInfo", ["ChannelAdvisor::OrderServiceSOAP::ShippingInfoSubmit", XSD::QName.new(NsOrders, "ShippingInfo")], [0, 1]]
+    ]
+  )
+
+  LiteralRegistry.register(
+    :class => ChannelAdvisor::OrderServiceSOAP::OrderStatus,
+    :schema_type => XSD::QName.new(NsOrders, "OrderStatus"),
+    :schema_element => [
+      ["checkoutStatus", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "CheckoutStatus")], [0, 1]],
+      ["checkoutDateGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "CheckoutDateGMT")]],
+      ["paymentStatus", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "PaymentStatus")], [0, 1]],
+      ["paymentDateGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "PaymentDateGMT")]],
+      ["shippingStatus", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ShippingStatus")], [0, 1]],
+      ["shippingDateGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "ShippingDateGMT")]],
+      ["orderRefundStatus", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "OrderRefundStatus")], [0, 1]]
     ]
   )
 
@@ -1372,10 +1476,10 @@ module DefaultMappingRegistry
     :schema_type => XSD::QName.new(NsOrders, "OrderCart"),
     :schema_element => [
       ["cartID", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "CartID")]],
-      ["checkoutSource", ["ChannelAdvisor::OrderServiceSOAP::CheckoutSourceType", XSD::QName.new(NsOrders, "CheckoutSource")]],
-      ["vATTaxCalculationOption", ["ChannelAdvisor::OrderServiceSOAP::VAT_Calculation_Type", XSD::QName.new(NsOrders, "VATTaxCalculationOption")]],
-      ["vATShippingOption", ["ChannelAdvisor::OrderServiceSOAP::VAT_Calculation_Type", XSD::QName.new(NsOrders, "VATShippingOption")]],
-      ["vATGiftWrapOption", ["ChannelAdvisor::OrderServiceSOAP::VAT_Calculation_Type", XSD::QName.new(NsOrders, "VATGiftWrapOption")]],
+      ["checkoutSource", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "CheckoutSource")], [0, 1]],
+      ["vATTaxCalculationOption", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "VATTaxCalculationOption")], [0, 1]],
+      ["vATShippingOption", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "VATShippingOption")], [0, 1]],
+      ["vATGiftWrapOption", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "VATGiftWrapOption")], [0, 1]],
       ["lineItemSKUList", ["ChannelAdvisor::OrderServiceSOAP::ArrayOfOrderLineItemItem", XSD::QName.new(NsOrders, "LineItemSKUList")], [0, 1]],
       ["lineItemInvoiceList", ["ChannelAdvisor::OrderServiceSOAP::ArrayOfOrderLineItemInvoice", XSD::QName.new(NsOrders, "LineItemInvoiceList")], [0, 1]],
       ["lineItemPromoList", ["ChannelAdvisor::OrderServiceSOAP::ArrayOfOrderLineItemPromo", XSD::QName.new(NsOrders, "LineItemPromoList")], [0, 1]]
@@ -1395,12 +1499,12 @@ module DefaultMappingRegistry
     :schema_type => XSD::QName.new(NsOrders, "OrderLineItemItem"),
     :schema_basetype => XSD::QName.new(NsOrders, "OrderLineItemBase"),
     :schema_element => [
-      ["lineItemType", ["ChannelAdvisor::OrderServiceSOAP::LineItemTypeCode", XSD::QName.new(NsOrders, "LineItemType")]],
+      ["lineItemType", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "LineItemType")], [0, 1]],
       ["unitPrice", ["SOAP::SOAPDecimal", XSD::QName.new(NsOrders, "UnitPrice")]],
       ["lineItemID", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "LineItemID")]],
       ["allowNegativeQuantity", ["SOAP::SOAPBoolean", XSD::QName.new(NsOrders, "AllowNegativeQuantity")]],
       ["quantity", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "Quantity")]],
-      ["itemSaleSource", ["ChannelAdvisor::OrderServiceSOAP::SiteToken", XSD::QName.new(NsOrders, "ItemSaleSource")]],
+      ["itemSaleSource", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ItemSaleSource")], [0, 1]],
       ["sKU", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "SKU")], [0, 1]],
       ["title", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "Title")], [0, 1]],
       ["buyerUserID", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "BuyerUserID")], [0, 1]],
@@ -1414,7 +1518,9 @@ module DefaultMappingRegistry
       ["giftWrapTaxCost", ["SOAP::SOAPDecimal", XSD::QName.new(NsOrders, "GiftWrapTaxCost")]],
       ["giftMessage", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "GiftMessage")], [0, 1]],
       ["giftWrapLevel", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "GiftWrapLevel")], [0, 1]],
-      ["itemPromoList", ["ChannelAdvisor::OrderServiceSOAP::ArrayOfOrderLineItemItemPromo", XSD::QName.new(NsOrders, "ItemPromoList")], [0, 1]]
+      ["itemPromoList", ["ChannelAdvisor::OrderServiceSOAP::ArrayOfOrderLineItemItemPromo", XSD::QName.new(NsOrders, "ItemPromoList")], [0, 1]],
+      ["recyclingFee", ["SOAP::SOAPDecimal", XSD::QName.new(NsOrders, "RecyclingFee")]],
+      ["fulfillmentType", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "FulfillmentType")], [0, 1]]
     ]
   )
 
@@ -1423,7 +1529,7 @@ module DefaultMappingRegistry
     :schema_type => XSD::QName.new(NsOrders, "OrderLineItemPromo"),
     :schema_basetype => XSD::QName.new(NsOrders, "OrderLineItemBase"),
     :schema_element => [
-      ["lineItemType", ["ChannelAdvisor::OrderServiceSOAP::LineItemTypeCode", XSD::QName.new(NsOrders, "LineItemType")]],
+      ["lineItemType", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "LineItemType")], [0, 1]],
       ["unitPrice", ["SOAP::SOAPDecimal", XSD::QName.new(NsOrders, "UnitPrice")]],
       ["promoCode", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "PromoCode")], [0, 1]]
     ]
@@ -1434,7 +1540,7 @@ module DefaultMappingRegistry
     :schema_type => XSD::QName.new(NsOrders, "OrderLineItemItemPromo"),
     :schema_basetype => XSD::QName.new(NsOrders, "OrderLineItemPromo"),
     :schema_element => [
-      ["lineItemType", ["ChannelAdvisor::OrderServiceSOAP::LineItemTypeCode", XSD::QName.new(NsOrders, "LineItemType")]],
+      ["lineItemType", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "LineItemType")], [0, 1]],
       ["unitPrice", ["SOAP::SOAPDecimal", XSD::QName.new(NsOrders, "UnitPrice")]],
       ["promoCode", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "PromoCode")], [0, 1]],
       ["shippingPrice", ["SOAP::SOAPDecimal", XSD::QName.new(NsOrders, "ShippingPrice")]]
@@ -1446,7 +1552,7 @@ module DefaultMappingRegistry
     :schema_type => XSD::QName.new(NsOrders, "OrderLineItemInvoice"),
     :schema_basetype => XSD::QName.new(NsOrders, "OrderLineItemBase"),
     :schema_element => [
-      ["lineItemType", ["ChannelAdvisor::OrderServiceSOAP::LineItemTypeCode", XSD::QName.new(NsOrders, "LineItemType")]],
+      ["lineItemType", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "LineItemType")], [0, 1]],
       ["unitPrice", ["SOAP::SOAPDecimal", XSD::QName.new(NsOrders, "UnitPrice")]]
     ]
   )
@@ -1464,12 +1570,12 @@ module DefaultMappingRegistry
     :schema_type => XSD::QName.new(NsOrders, "OrderLineItemItemResponse"),
     :schema_basetype => XSD::QName.new(NsOrders, "OrderLineItemItem"),
     :schema_element => [
-      ["lineItemType", ["ChannelAdvisor::OrderServiceSOAP::LineItemTypeCode", XSD::QName.new(NsOrders, "LineItemType")]],
+      ["lineItemType", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "LineItemType")], [0, 1]],
       ["unitPrice", ["SOAP::SOAPDecimal", XSD::QName.new(NsOrders, "UnitPrice")]],
       ["lineItemID", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "LineItemID")]],
       ["allowNegativeQuantity", ["SOAP::SOAPBoolean", XSD::QName.new(NsOrders, "AllowNegativeQuantity")]],
       ["quantity", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "Quantity")]],
-      ["itemSaleSource", ["ChannelAdvisor::OrderServiceSOAP::SiteToken", XSD::QName.new(NsOrders, "ItemSaleSource")]],
+      ["itemSaleSource", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ItemSaleSource")], [0, 1]],
       ["sKU", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "SKU")], [0, 1]],
       ["title", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "Title")], [0, 1]],
       ["buyerUserID", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "BuyerUserID")], [0, 1]],
@@ -1484,10 +1590,14 @@ module DefaultMappingRegistry
       ["giftMessage", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "GiftMessage")], [0, 1]],
       ["giftWrapLevel", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "GiftWrapLevel")], [0, 1]],
       ["itemPromoList", ["ChannelAdvisor::OrderServiceSOAP::ArrayOfOrderLineItemItemPromo", XSD::QName.new(NsOrders, "ItemPromoList")], [0, 1]],
+      ["recyclingFee", ["SOAP::SOAPDecimal", XSD::QName.new(NsOrders, "RecyclingFee")]],
+      ["fulfillmentType", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "FulfillmentType")], [0, 1]],
       ["unitWeight", ["ChannelAdvisor::OrderServiceSOAP::ItemWeight", XSD::QName.new(NsOrders, "UnitWeight")], [0, 1]],
       ["warehouseLocation", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "WarehouseLocation")], [0, 1]],
       ["userName", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "UserName")], [0, 1]],
-      ["distributionCenterCode", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "DistributionCenterCode")], [0, 1]]
+      ["distributionCenterCode", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "DistributionCenterCode")], [0, 1]],
+      ["isExternallyFulfilled", ["SOAP::SOAPBoolean", XSD::QName.new(NsOrders, "IsExternallyFulfilled")]],
+      ["itemSaleSourceTransactionID", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ItemSaleSourceTransactionID")], [0, 1]]
     ]
   )
 
@@ -1516,35 +1626,6 @@ module DefaultMappingRegistry
   )
 
   LiteralRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::OrderResponseDetailComplete,
-    :schema_type => XSD::QName.new(NsOrders, "OrderResponseDetailComplete"),
-    :schema_basetype => XSD::QName.new(NsOrders, "OrderResponseDetailHigh"),
-    :schema_element => [
-      ["numberOfMatches", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "NumberOfMatches")]],
-      ["orderTimeGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "OrderTimeGMT")]],
-      ["lastUpdateDate", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "LastUpdateDate")]],
-      ["totalOrderAmount", ["SOAP::SOAPDecimal", XSD::QName.new(NsOrders, "TotalOrderAmount")]],
-      ["orderState", ["ChannelAdvisor::OrderServiceSOAP::OrderStateCode", XSD::QName.new(NsOrders, "OrderState")]],
-      ["dateCancelledGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "DateCancelledGMT")]],
-      ["orderID", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "OrderID")]],
-      ["clientOrderIdentifier", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ClientOrderIdentifier")], [0, 1]],
-      ["flagStyle", ["ChannelAdvisor::OrderServiceSOAP::FlagType", XSD::QName.new(NsOrders, "FlagStyle")]],
-      ["orderStatus", ["ChannelAdvisor::OrderServiceSOAP::OrderStatus", XSD::QName.new(NsOrders, "OrderStatus")], [0, 1]],
-      ["resellerID", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ResellerID")], [0, 1]],
-      ["buyerEmailAddress", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "BuyerEmailAddress")], [0, 1]],
-      ["emailOptIn", ["SOAP::SOAPBoolean", XSD::QName.new(NsOrders, "EmailOptIn")]],
-      ["paymentInfo", ["ChannelAdvisor::OrderServiceSOAP::PaymentInfoResponse", XSD::QName.new(NsOrders, "PaymentInfo")], [0, 1]],
-      ["shippingInfo", ["ChannelAdvisor::OrderServiceSOAP::ShippingInfoResponse", XSD::QName.new(NsOrders, "ShippingInfo")], [0, 1]],
-      ["billingInfo", ["ChannelAdvisor::OrderServiceSOAP::BillingInfo", XSD::QName.new(NsOrders, "BillingInfo")], [0, 1]],
-      ["flagDescription", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "FlagDescription")], [0, 1]],
-      ["shoppingCart", ["ChannelAdvisor::OrderServiceSOAP::OrderCart", XSD::QName.new(NsOrders, "ShoppingCart")], [0, 1]],
-      ["customValueList", ["ChannelAdvisor::OrderServiceSOAP::ArrayOfCustomValue", XSD::QName.new(NsOrders, "CustomValueList")], [0, 1]],
-      ["buyerIpAddress", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "BuyerIpAddress")], [0, 1]],
-      ["transactionNotes", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "TransactionNotes")], [0, 1]]
-    ]
-  )
-
-  LiteralRegistry.register(
     :class => ChannelAdvisor::OrderServiceSOAP::ArrayOfCustomValue,
     :schema_type => XSD::QName.new(NsOrders, "ArrayOfCustomValue"),
     :schema_element => [
@@ -1562,25 +1643,6 @@ module DefaultMappingRegistry
   )
 
   LiteralRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::OrderSubmit,
-    :schema_type => XSD::QName.new(NsOrders, "OrderSubmit"),
-    :schema_basetype => XSD::QName.new(NsOrders, "Order"),
-    :schema_element => [
-      ["orderTimeGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "OrderTimeGMT")]],
-      ["clientOrderIdentifier", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ClientOrderIdentifier")], [0, 1]],
-      ["orderStatus", ["ChannelAdvisor::OrderServiceSOAP::OrderStatus", XSD::QName.new(NsOrders, "OrderStatus")], [0, 1]],
-      ["buyerEmailAddress", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "BuyerEmailAddress")], [0, 1]],
-      ["emailOptIn", ["SOAP::SOAPBoolean", XSD::QName.new(NsOrders, "EmailOptIn")]],
-      ["resellerID", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ResellerID")], [0, 1]],
-      ["billingInfo", ["ChannelAdvisor::OrderServiceSOAP::BillingInfo", XSD::QName.new(NsOrders, "BillingInfo")], [0, 1]],
-      ["paymentInfo", ["ChannelAdvisor::OrderServiceSOAP::PaymentInfo", XSD::QName.new(NsOrders, "PaymentInfo")], [0, 1]],
-      ["shoppingCart", ["ChannelAdvisor::OrderServiceSOAP::OrderCart", XSD::QName.new(NsOrders, "ShoppingCart")], [0, 1]],
-      ["customValueList", ["ChannelAdvisor::OrderServiceSOAP::ArrayOfCustomValue", XSD::QName.new(NsOrders, "CustomValueList")], [0, 1]],
-      ["shippingInfo", ["ChannelAdvisor::OrderServiceSOAP::ShippingInfoSubmit", XSD::QName.new(NsOrders, "ShippingInfo")], [0, 1]]
-    ]
-  )
-
-  LiteralRegistry.register(
     :class => ChannelAdvisor::OrderServiceSOAP::ShippingInfoSubmit,
     :schema_type => XSD::QName.new(NsOrders, "ShippingInfoSubmit"),
     :schema_basetype => XSD::QName.new(NsOrders, "ShippingInfo"),
@@ -1589,6 +1651,7 @@ module DefaultMappingRegistry
       ["addressLine2", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "AddressLine2")], [0, 1]],
       ["city", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "City")], [0, 1]],
       ["region", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "Region")], [0, 1]],
+      ["regionDescription", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "RegionDescription")], [0, 1]],
       ["postalCode", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "PostalCode")], [0, 1]],
       ["countryCode", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "CountryCode")], [0, 1]],
       ["companyName", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "CompanyName")], [0, 1]],
@@ -1600,115 +1663,225 @@ module DefaultMappingRegistry
       ["phoneNumberDay", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "PhoneNumberDay")], [0, 1]],
       ["phoneNumberEvening", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "PhoneNumberEvening")], [0, 1]],
       ["shipmentList", ["ChannelAdvisor::OrderServiceSOAP::ArrayOfShipment", XSD::QName.new(NsOrders, "ShipmentList")], [0, 1]],
-      ["shippingInstructions", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ShippingInstructions")], [0, 1]]
+      ["shippingInstructions", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ShippingInstructions")], [0, 1]],
+      ["estimatedShipDate", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "EstimatedShipDate")]],
+      ["deliveryDate", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "DeliveryDate")]]
     ]
   )
 
   LiteralRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::OrderRefundHistoryResponse,
-    :schema_type => XSD::QName.new(NsOrders, "OrderRefundHistoryResponse"),
+    :class => ChannelAdvisor::OrderServiceSOAP::ArrayOfShipment,
+    :schema_type => XSD::QName.new(NsOrders, "ArrayOfShipment"),
     :schema_element => [
+      ["shipment", ["ChannelAdvisor::OrderServiceSOAP::Shipment[]", XSD::QName.new(NsOrders, "Shipment")], [0, nil]]
+    ]
+  )
+
+  LiteralRegistry.register(
+    :class => ChannelAdvisor::OrderServiceSOAP::Shipment,
+    :schema_type => XSD::QName.new(NsOrders, "Shipment"),
+    :schema_element => [
+      ["shippingCarrier", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ShippingCarrier")], [0, 1]],
+      ["shippingClass", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ShippingClass")], [0, 1]],
+      ["trackingNumber", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "TrackingNumber")], [0, 1]]
+    ]
+  )
+
+  LiteralRegistry.register(
+    :class => ChannelAdvisor::OrderServiceSOAP::ShippingInfoResponse,
+    :schema_type => XSD::QName.new(NsOrders, "ShippingInfoResponse"),
+    :schema_basetype => XSD::QName.new(NsOrders, "ShippingInfo"),
+    :schema_element => [
+      ["addressLine1", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "AddressLine1")], [0, 1]],
+      ["addressLine2", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "AddressLine2")], [0, 1]],
+      ["city", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "City")], [0, 1]],
+      ["region", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "Region")], [0, 1]],
+      ["regionDescription", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "RegionDescription")], [0, 1]],
+      ["postalCode", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "PostalCode")], [0, 1]],
+      ["countryCode", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "CountryCode")], [0, 1]],
+      ["companyName", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "CompanyName")], [0, 1]],
+      ["jobTitle", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "JobTitle")], [0, 1]],
+      ["title", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "Title")], [0, 1]],
+      ["firstName", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "FirstName")], [0, 1]],
+      ["lastName", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "LastName")], [0, 1]],
+      ["suffix", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "Suffix")], [0, 1]],
+      ["phoneNumberDay", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "PhoneNumberDay")], [0, 1]],
+      ["phoneNumberEvening", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "PhoneNumberEvening")], [0, 1]],
+      ["shipmentList", ["ChannelAdvisor::OrderServiceSOAP::ArrayOfShipment", XSD::QName.new(NsOrders, "ShipmentList")], [0, 1]],
+      ["shippingInstructions", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ShippingInstructions")], [0, 1]],
+      ["estimatedShipDate", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "EstimatedShipDate")]],
+      ["deliveryDate", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "DeliveryDate")]]
+    ]
+  )
+
+  LiteralRegistry.register(
+    :class => ChannelAdvisor::OrderServiceSOAP::OrderCriteria,
+    :schema_type => XSD::QName.new(NsOrders, "OrderCriteria"),
+    :schema_element => [
+      ["orderCreationFilterBeginTimeGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "OrderCreationFilterBeginTimeGMT")]],
+      ["orderCreationFilterEndTimeGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "OrderCreationFilterEndTimeGMT")]],
+      ["statusUpdateFilterBeginTimeGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "StatusUpdateFilterBeginTimeGMT")]],
+      ["statusUpdateFilterEndTimeGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "StatusUpdateFilterEndTimeGMT")]],
+      ["joinDateFiltersWithOr", ["SOAP::SOAPBoolean", XSD::QName.new(NsOrders, "JoinDateFiltersWithOr")]],
+      ["detailLevel", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "DetailLevel")], [0, 1]],
+      ["exportState", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ExportState")], [0, 1]],
+      ["orderIDList", ["ChannelAdvisor::OrderServiceSOAP::ArrayOfInt_", XSD::QName.new(NsOrders, "OrderIDList")], [0, 1]],
+      ["clientOrderIdentifierList", ["ChannelAdvisor::OrderServiceSOAP::ArrayOfString_", XSD::QName.new(NsOrders, "ClientOrderIdentifierList")], [0, 1]],
+      ["orderStateFilter", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "OrderStateFilter")], [0, 1]],
+      ["paymentStatusFilter", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "PaymentStatusFilter")], [0, 1]],
+      ["checkoutStatusFilter", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "CheckoutStatusFilter")], [0, 1]],
+      ["shippingStatusFilter", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ShippingStatusFilter")], [0, 1]],
+      ["refundStatusFilter", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "RefundStatusFilter")], [0, 1]],
+      ["distributionCenterCode", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "DistributionCenterCode")], [0, 1]],
+      ["fulfillmentTypeFilter", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "FulfillmentTypeFilter")], [0, 1]],
+      ["pageNumberFilter", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "PageNumberFilter")]],
+      ["pageSize", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "PageSize")]]
+    ]
+  )
+
+  LiteralRegistry.register(
+    :class => ChannelAdvisor::OrderServiceSOAP::ArrayOfInt_,
+    :schema_type => XSD::QName.new(NsOrders, "ArrayOfInt"),
+    :schema_element => [
+      ["int", "SOAP::SOAPInt[]", [0, nil]]
+    ]
+  )
+
+  LiteralRegistry.register(
+    :class => ChannelAdvisor::OrderServiceSOAP::ArrayOfString_,
+    :schema_type => XSD::QName.new(NsOrders, "ArrayOfString"),
+    :schema_element => [
+      ["string", "SOAP::SOAPString[]", [0, nil]]
+    ]
+  )
+
+  LiteralRegistry.register(
+    :class => ChannelAdvisor::OrderServiceSOAP::OrderResponseDetailLow,
+    :schema_type => XSD::QName.new(NsOrders, "OrderResponseDetailLow"),
+    :schema_basetype => XSD::QName.new(NsOrders, "OrderResponseItem"),
+    :schema_element => [
+      ["numberOfMatches", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "NumberOfMatches")]],
+      ["orderTimeGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "OrderTimeGMT")]],
+      ["lastUpdateDate", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "LastUpdateDate")]],
+      ["totalOrderAmount", ["SOAP::SOAPDecimal", XSD::QName.new(NsOrders, "TotalOrderAmount")]],
+      ["orderState", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "OrderState")], [0, 1]],
+      ["dateCancelledGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "DateCancelledGMT")]],
       ["orderID", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "OrderID")]],
       ["clientOrderIdentifier", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ClientOrderIdentifier")], [0, 1]],
-      ["refundStatus", ["ChannelAdvisor::OrderServiceSOAP::OrderRefundStatusCode", XSD::QName.new(NsOrders, "RefundStatus")]],
-      ["lineItemRefunds", ["ChannelAdvisor::OrderServiceSOAP::ArrayOfOrderLineItemRefundHistoryResponse", XSD::QName.new(NsOrders, "LineItemRefunds")], [0, 1]]
+      ["sellerOrderID", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "SellerOrderID")], [0, 1]],
+      ["flagStyle", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "FlagStyle")], [0, 1]],
+      ["orderStatus", ["ChannelAdvisor::OrderServiceSOAP::OrderStatus", XSD::QName.new(NsOrders, "OrderStatus")], [0, 1]]
     ]
   )
 
   LiteralRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::ArrayOfOrderLineItemRefundHistoryResponse,
-    :schema_type => XSD::QName.new(NsOrders, "ArrayOfOrderLineItemRefundHistoryResponse"),
+    :class => ChannelAdvisor::OrderServiceSOAP::OrderResponseDetailMedium,
+    :schema_type => XSD::QName.new(NsOrders, "OrderResponseDetailMedium"),
+    :schema_basetype => XSD::QName.new(NsOrders, "OrderResponseDetailLow"),
     :schema_element => [
-      ["orderLineItemRefundHistoryResponse", ["ChannelAdvisor::OrderServiceSOAP::OrderLineItemRefundHistoryResponse[]", XSD::QName.new(NsOrders, "OrderLineItemRefundHistoryResponse")], [0, nil]]
+      ["numberOfMatches", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "NumberOfMatches")]],
+      ["orderTimeGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "OrderTimeGMT")]],
+      ["lastUpdateDate", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "LastUpdateDate")]],
+      ["totalOrderAmount", ["SOAP::SOAPDecimal", XSD::QName.new(NsOrders, "TotalOrderAmount")]],
+      ["orderState", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "OrderState")], [0, 1]],
+      ["dateCancelledGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "DateCancelledGMT")]],
+      ["orderID", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "OrderID")]],
+      ["clientOrderIdentifier", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ClientOrderIdentifier")], [0, 1]],
+      ["sellerOrderID", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "SellerOrderID")], [0, 1]],
+      ["flagStyle", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "FlagStyle")], [0, 1]],
+      ["orderStatus", ["ChannelAdvisor::OrderServiceSOAP::OrderStatus", XSD::QName.new(NsOrders, "OrderStatus")], [0, 1]],
+      ["resellerID", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ResellerID")], [0, 1]],
+      ["buyerEmailAddress", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "BuyerEmailAddress")], [0, 1]],
+      ["emailOptIn", ["SOAP::SOAPBoolean", XSD::QName.new(NsOrders, "EmailOptIn")]],
+      ["paymentInfo", ["ChannelAdvisor::OrderServiceSOAP::PaymentInfoResponse", XSD::QName.new(NsOrders, "PaymentInfo")], [0, 1]],
+      ["shippingInfo", ["ChannelAdvisor::OrderServiceSOAP::ShippingInfoResponse", XSD::QName.new(NsOrders, "ShippingInfo")], [0, 1]],
+      ["billingInfo", ["ChannelAdvisor::OrderServiceSOAP::BillingInfo", XSD::QName.new(NsOrders, "BillingInfo")], [0, 1]],
+      ["flagDescription", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "FlagDescription")], [0, 1]]
+    ]
+  )
+
+  LiteralRegistry.register(
+    :class => ChannelAdvisor::OrderServiceSOAP::PaymentInfoResponse,
+    :schema_type => XSD::QName.new(NsOrders, "PaymentInfoResponse"),
+    :schema_basetype => XSD::QName.new(NsOrders, "PaymentInfo"),
+    :schema_element => [
+      ["paymentType", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "PaymentType")], [0, 1]],
+      ["creditCardLast4", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "CreditCardLast4")], [0, 1]],
+      ["payPalID", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "PayPalID")], [0, 1]],
+      ["merchantReferenceNumber", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "MerchantReferenceNumber")], [0, 1]],
+      ["paymentTransactionID", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "PaymentTransactionID")], [0, 1]]
+    ]
+  )
+
+  LiteralRegistry.register(
+    :class => ChannelAdvisor::OrderServiceSOAP::OrderResponseDetailHigh,
+    :schema_type => XSD::QName.new(NsOrders, "OrderResponseDetailHigh"),
+    :schema_basetype => XSD::QName.new(NsOrders, "OrderResponseDetailMedium"),
+    :schema_element => [
+      ["numberOfMatches", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "NumberOfMatches")]],
+      ["orderTimeGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "OrderTimeGMT")]],
+      ["lastUpdateDate", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "LastUpdateDate")]],
+      ["totalOrderAmount", ["SOAP::SOAPDecimal", XSD::QName.new(NsOrders, "TotalOrderAmount")]],
+      ["orderState", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "OrderState")], [0, 1]],
+      ["dateCancelledGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "DateCancelledGMT")]],
+      ["orderID", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "OrderID")]],
+      ["clientOrderIdentifier", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ClientOrderIdentifier")], [0, 1]],
+      ["sellerOrderID", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "SellerOrderID")], [0, 1]],
+      ["flagStyle", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "FlagStyle")], [0, 1]],
+      ["orderStatus", ["ChannelAdvisor::OrderServiceSOAP::OrderStatus", XSD::QName.new(NsOrders, "OrderStatus")], [0, 1]],
+      ["resellerID", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ResellerID")], [0, 1]],
+      ["buyerEmailAddress", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "BuyerEmailAddress")], [0, 1]],
+      ["emailOptIn", ["SOAP::SOAPBoolean", XSD::QName.new(NsOrders, "EmailOptIn")]],
+      ["paymentInfo", ["ChannelAdvisor::OrderServiceSOAP::PaymentInfoResponse", XSD::QName.new(NsOrders, "PaymentInfo")], [0, 1]],
+      ["shippingInfo", ["ChannelAdvisor::OrderServiceSOAP::ShippingInfoResponse", XSD::QName.new(NsOrders, "ShippingInfo")], [0, 1]],
+      ["billingInfo", ["ChannelAdvisor::OrderServiceSOAP::BillingInfo", XSD::QName.new(NsOrders, "BillingInfo")], [0, 1]],
+      ["flagDescription", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "FlagDescription")], [0, 1]],
+      ["shoppingCart", ["ChannelAdvisor::OrderServiceSOAP::OrderCart", XSD::QName.new(NsOrders, "ShoppingCart")], [0, 1]]
+    ]
+  )
+
+  LiteralRegistry.register(
+    :class => ChannelAdvisor::OrderServiceSOAP::OrderResponseDetailComplete,
+    :schema_type => XSD::QName.new(NsOrders, "OrderResponseDetailComplete"),
+    :schema_basetype => XSD::QName.new(NsOrders, "OrderResponseDetailHigh"),
+    :schema_element => [
+      ["numberOfMatches", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "NumberOfMatches")]],
+      ["orderTimeGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "OrderTimeGMT")]],
+      ["lastUpdateDate", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "LastUpdateDate")]],
+      ["totalOrderAmount", ["SOAP::SOAPDecimal", XSD::QName.new(NsOrders, "TotalOrderAmount")]],
+      ["orderState", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "OrderState")], [0, 1]],
+      ["dateCancelledGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsOrders, "DateCancelledGMT")]],
+      ["orderID", ["SOAP::SOAPInt", XSD::QName.new(NsOrders, "OrderID")]],
+      ["clientOrderIdentifier", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ClientOrderIdentifier")], [0, 1]],
+      ["sellerOrderID", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "SellerOrderID")], [0, 1]],
+      ["flagStyle", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "FlagStyle")], [0, 1]],
+      ["orderStatus", ["ChannelAdvisor::OrderServiceSOAP::OrderStatus", XSD::QName.new(NsOrders, "OrderStatus")], [0, 1]],
+      ["resellerID", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "ResellerID")], [0, 1]],
+      ["buyerEmailAddress", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "BuyerEmailAddress")], [0, 1]],
+      ["emailOptIn", ["SOAP::SOAPBoolean", XSD::QName.new(NsOrders, "EmailOptIn")]],
+      ["paymentInfo", ["ChannelAdvisor::OrderServiceSOAP::PaymentInfoResponse", XSD::QName.new(NsOrders, "PaymentInfo")], [0, 1]],
+      ["shippingInfo", ["ChannelAdvisor::OrderServiceSOAP::ShippingInfoResponse", XSD::QName.new(NsOrders, "ShippingInfo")], [0, 1]],
+      ["billingInfo", ["ChannelAdvisor::OrderServiceSOAP::BillingInfo", XSD::QName.new(NsOrders, "BillingInfo")], [0, 1]],
+      ["flagDescription", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "FlagDescription")], [0, 1]],
+      ["shoppingCart", ["ChannelAdvisor::OrderServiceSOAP::OrderCart", XSD::QName.new(NsOrders, "ShoppingCart")], [0, 1]],
+      ["customValueList", ["ChannelAdvisor::OrderServiceSOAP::ArrayOfCustomValue", XSD::QName.new(NsOrders, "CustomValueList")], [0, 1]],
+      ["buyerIpAddress", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "BuyerIpAddress")], [0, 1]],
+      ["transactionNotes", ["SOAP::SOAPString", XSD::QName.new(NsOrders, "TransactionNotes")], [0, 1]]
     ]
   )
 
   LiteralRegistry.register(
     :class => ChannelAdvisor::OrderServiceSOAP::ResultStatus,
     :schema_type => XSD::QName.new(NsWebservices, "ResultStatus")
-  )
-
-  LiteralRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::RefundAdjustmentReason,
-    :schema_type => XSD::QName.new(NsOrders, "RefundAdjustmentReason")
-  )
-
-  LiteralRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::SiteToken,
-    :schema_type => XSD::QName.new(NsOrders, "SiteToken")
-  )
-
-  LiteralRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::AsyncStatusCode,
-    :schema_type => XSD::QName.new(NsOrders, "AsyncStatusCode")
-  )
-
-  LiteralRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::DetailLevelType,
-    :schema_type => XSD::QName.new(NsOrders, "DetailLevelType")
-  )
-
-  LiteralRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::ExportStateType,
-    :schema_type => XSD::QName.new(NsOrders, "ExportStateType")
-  )
-
-  LiteralRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::OrderStateCode,
-    :schema_type => XSD::QName.new(NsOrders, "OrderStateCode")
-  )
-
-  LiteralRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::PaymentStatusCode,
-    :schema_type => XSD::QName.new(NsOrders, "PaymentStatusCode")
-  )
-
-  LiteralRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::CheckoutStatusCode,
-    :schema_type => XSD::QName.new(NsOrders, "CheckoutStatusCode")
-  )
-
-  LiteralRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::ShippingStatusCode,
-    :schema_type => XSD::QName.new(NsOrders, "ShippingStatusCode")
-  )
-
-  LiteralRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::FlagType,
-    :schema_type => XSD::QName.new(NsOrders, "FlagType")
-  )
-
-  LiteralRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::OrderRefundStatusCode,
-    :schema_type => XSD::QName.new(NsOrders, "OrderRefundStatusCode")
-  )
-
-  LiteralRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::CheckoutSourceType,
-    :schema_type => XSD::QName.new(NsOrders, "CheckoutSourceType")
-  )
-
-  LiteralRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::VAT_Calculation_Type,
-    :schema_type => XSD::QName.new(NsOrders, "VAT_Calculation_Type")
-  )
-
-  LiteralRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::LineItemTypeCode,
-    :schema_type => XSD::QName.new(NsOrders, "LineItemTypeCode")
-  )
-
-  LiteralRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::CheckoutPaymentStatusCode,
-    :schema_type => XSD::QName.new(NsOrders, "CheckoutPaymentStatusCode")
   )
 
   LiteralRegistry.register(
     :class => ChannelAdvisor::OrderServiceSOAP::SetOrdersExportStatus,
     :schema_name => XSD::QName.new(NsWebservices, "SetOrdersExportStatus"),
     :schema_element => [
-      ["accountID", "SOAP::SOAPString", [0, 1]],
-      ["clientOrderIdentifiers", "ChannelAdvisor::OrderServiceSOAP::ArrayOfString", [0, 1]],
+      ["accountID", "SOAP::SOAPString"],
+      ["orderIDList", "ChannelAdvisor::OrderServiceSOAP::ArrayOfInt", [0, 1]],
+      ["clientOrderIdentifierList", "ChannelAdvisor::OrderServiceSOAP::ArrayOfString", [0, 1]],
       ["markAsExported", "SOAP::SOAPBoolean"]
     ]
   )
@@ -1717,7 +1890,7 @@ module DefaultMappingRegistry
     :class => ChannelAdvisor::OrderServiceSOAP::SetOrdersExportStatusResponse,
     :schema_name => XSD::QName.new(NsWebservices, "SetOrdersExportStatusResponse"),
     :schema_element => [
-      ["setOrdersExportStatusResult", ["ChannelAdvisor::OrderServiceSOAP::APIResultOfArrayOfBoolean", XSD::QName.new(NsWebservices, "SetOrdersExportStatusResult")], [0, 1]]
+      ["setOrdersExportStatusResult", ["ChannelAdvisor::OrderServiceSOAP::APIResultOfArrayOfSetExportStatusResponse", XSD::QName.new(NsWebservices, "SetOrdersExportStatusResult")], [0, 1]]
     ]
   )
 
@@ -1734,8 +1907,8 @@ module DefaultMappingRegistry
     :class => ChannelAdvisor::OrderServiceSOAP::SubmitOrderRefund,
     :schema_name => XSD::QName.new(NsWebservices, "SubmitOrderRefund"),
     :schema_element => [
-      ["accountID", "SOAP::SOAPString", [0, 1]],
-      ["request", "ChannelAdvisor::OrderServiceSOAP::RefundOrderRequest", [0, 1]]
+      ["accountID", "SOAP::SOAPString"],
+      ["request", "ChannelAdvisor::OrderServiceSOAP::RefundOrderRequest"]
     ]
   )
 
@@ -1748,44 +1921,10 @@ module DefaultMappingRegistry
   )
 
   LiteralRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::GetOrderList,
-    :schema_name => XSD::QName.new(NsWebservices, "GetOrderList"),
-    :schema_element => [
-      ["accountID", "SOAP::SOAPString", [0, 1]],
-      ["orderCriteria", "ChannelAdvisor::OrderServiceSOAP::OrderCriteria", [0, 1]]
-    ]
-  )
-
-  LiteralRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::GetOrderListResponse,
-    :schema_name => XSD::QName.new(NsWebservices, "GetOrderListResponse"),
-    :schema_element => [
-      ["getOrderListResult", ["ChannelAdvisor::OrderServiceSOAP::APIResultOfArrayOfOrderResponseItem", XSD::QName.new(NsWebservices, "GetOrderListResult")], [0, 1]]
-    ]
-  )
-
-  LiteralRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::SubmitOrder,
-    :schema_name => XSD::QName.new(NsWebservices, "SubmitOrder"),
-    :schema_element => [
-      ["accountID", "SOAP::SOAPString", [0, 1]],
-      ["order", "ChannelAdvisor::OrderServiceSOAP::OrderSubmit", [0, 1]]
-    ]
-  )
-
-  LiteralRegistry.register(
-    :class => ChannelAdvisor::OrderServiceSOAP::SubmitOrderResponse,
-    :schema_name => XSD::QName.new(NsWebservices, "SubmitOrderResponse"),
-    :schema_element => [
-      ["submitOrderResult", ["ChannelAdvisor::OrderServiceSOAP::APIResultOfInt32", XSD::QName.new(NsWebservices, "SubmitOrderResult")], [0, 1]]
-    ]
-  )
-
-  LiteralRegistry.register(
     :class => ChannelAdvisor::OrderServiceSOAP::SetSellerOrderID,
     :schema_name => XSD::QName.new(NsWebservices, "SetSellerOrderID"),
     :schema_element => [
-      ["accountID", "SOAP::SOAPString", [0, 1]],
+      ["accountID", "SOAP::SOAPString"],
       ["orderIDList", "ChannelAdvisor::OrderServiceSOAP::ArrayOfInt", [0, 1]],
       ["sellerOrderIDList", "ChannelAdvisor::OrderServiceSOAP::ArrayOfString", [0, 1]]
     ]
@@ -1803,7 +1942,7 @@ module DefaultMappingRegistry
     :class => ChannelAdvisor::OrderServiceSOAP::SetSellerOrderItemIDList,
     :schema_name => XSD::QName.new(NsWebservices, "SetSellerOrderItemIDList"),
     :schema_element => [
-      ["accountID", "SOAP::SOAPString", [0, 1]],
+      ["accountID", "SOAP::SOAPString"],
       ["orderID", "SOAP::SOAPInt"],
       ["lineItemIDList", "ChannelAdvisor::OrderServiceSOAP::ArrayOfInt", [0, 1]],
       ["sellerOrderItemIDList", "ChannelAdvisor::OrderServiceSOAP::ArrayOfString", [0, 1]]
@@ -1822,7 +1961,7 @@ module DefaultMappingRegistry
     :class => ChannelAdvisor::OrderServiceSOAP::GetOrderRefundHistory,
     :schema_name => XSD::QName.new(NsWebservices, "GetOrderRefundHistory"),
     :schema_element => [
-      ["accountID", "SOAP::SOAPString", [0, 1]],
+      ["accountID", "SOAP::SOAPString"],
       ["orderID", "SOAP::SOAPInt"]
     ]
   )
@@ -1839,7 +1978,7 @@ module DefaultMappingRegistry
     :class => ChannelAdvisor::OrderServiceSOAP::UpdateOrderList,
     :schema_name => XSD::QName.new(NsWebservices, "UpdateOrderList"),
     :schema_element => [
-      ["accountID", "SOAP::SOAPString", [0, 1]],
+      ["accountID", "SOAP::SOAPString"],
       ["updateOrderSubmitList", "ChannelAdvisor::OrderServiceSOAP::ArrayOfOrderUpdateSubmit", [0, 1]]
     ]
   )
@@ -1849,6 +1988,76 @@ module DefaultMappingRegistry
     :schema_name => XSD::QName.new(NsWebservices, "UpdateOrderListResponse"),
     :schema_element => [
       ["updateOrderListResult", ["ChannelAdvisor::OrderServiceSOAP::APIResultOfArrayOfOrderUpdateResponse", XSD::QName.new(NsWebservices, "UpdateOrderListResult")], [0, 1]]
+    ]
+  )
+
+  LiteralRegistry.register(
+    :class => ChannelAdvisor::OrderServiceSOAP::OrderMerge,
+    :schema_name => XSD::QName.new(NsWebservices, "OrderMerge"),
+    :schema_element => [
+      ["accountID", "SOAP::SOAPString"],
+      ["primaryOrderID", "SOAP::SOAPInt"],
+      ["orderIDMergeList", "ChannelAdvisor::OrderServiceSOAP::ArrayOfInt", [0, 1]]
+    ]
+  )
+
+  LiteralRegistry.register(
+    :class => ChannelAdvisor::OrderServiceSOAP::OrderMergeResponse,
+    :schema_name => XSD::QName.new(NsWebservices, "OrderMergeResponse"),
+    :schema_element => [
+      ["orderMergeResult", ["ChannelAdvisor::OrderServiceSOAP::APIResultOfBoolean", XSD::QName.new(NsWebservices, "OrderMergeResult")], [0, 1]]
+    ]
+  )
+
+  LiteralRegistry.register(
+    :class => ChannelAdvisor::OrderServiceSOAP::OrderSplit,
+    :schema_name => XSD::QName.new(NsWebservices, "OrderSplit"),
+    :schema_element => [
+      ["accountID", "SOAP::SOAPString"],
+      ["orderID", "SOAP::SOAPInt"],
+      ["lineItemIDList", "ChannelAdvisor::OrderServiceSOAP::ArrayOfInt", [0, 1]]
+    ]
+  )
+
+  LiteralRegistry.register(
+    :class => ChannelAdvisor::OrderServiceSOAP::OrderSplitResponse,
+    :schema_name => XSD::QName.new(NsWebservices, "OrderSplitResponse"),
+    :schema_element => [
+      ["orderSplitResult", ["ChannelAdvisor::OrderServiceSOAP::APIResultOfBoolean", XSD::QName.new(NsWebservices, "OrderSplitResult")], [0, 1]]
+    ]
+  )
+
+  LiteralRegistry.register(
+    :class => ChannelAdvisor::OrderServiceSOAP::SubmitOrder,
+    :schema_name => XSD::QName.new(NsWebservices, "SubmitOrder"),
+    :schema_element => [
+      ["accountID", "SOAP::SOAPString"],
+      ["order", "ChannelAdvisor::OrderServiceSOAP::OrderSubmit"]
+    ]
+  )
+
+  LiteralRegistry.register(
+    :class => ChannelAdvisor::OrderServiceSOAP::SubmitOrderResponse,
+    :schema_name => XSD::QName.new(NsWebservices, "SubmitOrderResponse"),
+    :schema_element => [
+      ["submitOrderResult", ["ChannelAdvisor::OrderServiceSOAP::APIResultOfInt32", XSD::QName.new(NsWebservices, "SubmitOrderResult")], [0, 1]]
+    ]
+  )
+
+  LiteralRegistry.register(
+    :class => ChannelAdvisor::OrderServiceSOAP::GetOrderList,
+    :schema_name => XSD::QName.new(NsWebservices, "GetOrderList"),
+    :schema_element => [
+      ["accountID", "SOAP::SOAPString"],
+      ["orderCriteria", "ChannelAdvisor::OrderServiceSOAP::OrderCriteria"]
+    ]
+  )
+
+  LiteralRegistry.register(
+    :class => ChannelAdvisor::OrderServiceSOAP::GetOrderListResponse,
+    :schema_name => XSD::QName.new(NsWebservices, "GetOrderListResponse"),
+    :schema_element => [
+      ["getOrderListResult", ["ChannelAdvisor::OrderServiceSOAP::APIResultOfArrayOfOrderResponseItem", XSD::QName.new(NsWebservices, "GetOrderListResult")], [0, 1]]
     ]
   )
 

--- a/lib/channel_advisor/order_service/types.rb
+++ b/lib/channel_advisor/order_service/types.rb
@@ -3,8 +3,111 @@ require 'xsd/qname'
 module ChannelAdvisor; module OrderServiceSOAP
 
 
+# {http://api.channeladvisor.com/webservices/}ArrayOfInt
+class ArrayOfInt < ::Array
+end
+
 # {http://api.channeladvisor.com/webservices/}ArrayOfString
 class ArrayOfString < ::Array
+end
+
+# {http://api.channeladvisor.com/webservices/}APIResultOfArrayOfSetExportStatusResponse
+#   status - ChannelAdvisor::OrderServiceSOAP::ResultStatus
+#   messageCode - SOAP::SOAPInt
+#   message - SOAP::SOAPString
+#   data - SOAP::SOAPString
+#   resultData - ChannelAdvisor::OrderServiceSOAP::ArrayOfSetExportStatusResponse
+class APIResultOfArrayOfSetExportStatusResponse
+  attr_accessor :status
+  attr_accessor :messageCode
+  attr_accessor :message
+  attr_accessor :data
+  attr_accessor :resultData
+
+  def initialize(status = nil, messageCode = nil, message = nil, data = nil, resultData = nil)
+    @status = status
+    @messageCode = messageCode
+    @message = message
+    @data = data
+    @resultData = resultData
+  end
+end
+
+# {http://api.channeladvisor.com/webservices/}ArrayOfSetExportStatusResponse
+class ArrayOfSetExportStatusResponse < ::Array
+end
+
+# {http://api.channeladvisor.com/webservices/}SetExportStatusResponse
+#   orderID - SOAP::SOAPInt
+#   clientOrderIdentifier - SOAP::SOAPString
+#   success - SOAP::SOAPBoolean
+class SetExportStatusResponse
+  attr_accessor :orderID
+  attr_accessor :clientOrderIdentifier
+  attr_accessor :success
+
+  def initialize(orderID = nil, clientOrderIdentifier = nil, success = nil)
+    @orderID = orderID
+    @clientOrderIdentifier = clientOrderIdentifier
+    @success = success
+  end
+end
+
+# {http://api.channeladvisor.com/webservices/}APICredentials
+#   developerKey - SOAP::SOAPString
+#   password - SOAP::SOAPString
+class APICredentials
+  attr_accessor :developerKey
+  attr_accessor :password
+
+  def initialize(developerKey = nil, password = nil)
+    @developerKey = developerKey
+    @password = password
+  end
+end
+
+# {http://api.channeladvisor.com/webservices/}APIResultOfRefundOrderResponse
+#   status - ChannelAdvisor::OrderServiceSOAP::ResultStatus
+#   messageCode - SOAP::SOAPInt
+#   message - SOAP::SOAPString
+#   data - SOAP::SOAPString
+#   resultData - ChannelAdvisor::OrderServiceSOAP::RefundOrderResponse
+class APIResultOfRefundOrderResponse
+  attr_accessor :status
+  attr_accessor :messageCode
+  attr_accessor :message
+  attr_accessor :data
+  attr_accessor :resultData
+
+  def initialize(status = nil, messageCode = nil, message = nil, data = nil, resultData = nil)
+    @status = status
+    @messageCode = messageCode
+    @message = message
+    @data = data
+    @resultData = resultData
+  end
+end
+
+# {http://api.channeladvisor.com/webservices/}APIResultOfArrayOfInt32
+#   status - ChannelAdvisor::OrderServiceSOAP::ResultStatus
+#   messageCode - SOAP::SOAPInt
+#   message - SOAP::SOAPString
+#   data - SOAP::SOAPString
+#   resultData - ChannelAdvisor::OrderServiceSOAP::ArrayOfInt
+class APIResultOfArrayOfInt32
+  attr_accessor :status
+  attr_accessor :messageCode
+  attr_accessor :message
+  attr_accessor :data
+  attr_accessor :resultData
+
+  def initialize(status = nil, messageCode = nil, message = nil, data = nil, resultData = nil)
+    @status = status
+    @messageCode = messageCode
+    @message = message
+    @data = data
+    @resultData = resultData
+  end
 end
 
 # {http://api.channeladvisor.com/webservices/}APIResultOfArrayOfBoolean
@@ -33,26 +136,200 @@ end
 class ArrayOfBoolean < ::Array
 end
 
-# {http://api.channeladvisor.com/webservices/}APICredentials
-#   developerKey - SOAP::SOAPString
-#   password - SOAP::SOAPString
-class APICredentials
-  attr_accessor :developerKey
-  attr_accessor :password
-
-  def initialize(developerKey = nil, password = nil)
-    @developerKey = developerKey
-    @password = password
-  end
-end
-
-# {http://api.channeladvisor.com/webservices/}APIResultOfRefundOrderResponse
+# {http://api.channeladvisor.com/webservices/}APIResultOfOrderRefundHistoryResponse
 #   status - ChannelAdvisor::OrderServiceSOAP::ResultStatus
 #   messageCode - SOAP::SOAPInt
 #   message - SOAP::SOAPString
 #   data - SOAP::SOAPString
-#   resultData - ChannelAdvisor::OrderServiceSOAP::RefundOrderResponse
-class APIResultOfRefundOrderResponse
+#   resultData - ChannelAdvisor::OrderServiceSOAP::OrderRefundHistoryResponse
+class APIResultOfOrderRefundHistoryResponse
+  attr_accessor :status
+  attr_accessor :messageCode
+  attr_accessor :message
+  attr_accessor :data
+  attr_accessor :resultData
+
+  def initialize(status = nil, messageCode = nil, message = nil, data = nil, resultData = nil)
+    @status = status
+    @messageCode = messageCode
+    @message = message
+    @data = data
+    @resultData = resultData
+  end
+end
+
+# {http://api.channeladvisor.com/webservices/}ArrayOfOrderUpdateSubmit
+class ArrayOfOrderUpdateSubmit < ::Array
+end
+
+# {http://api.channeladvisor.com/webservices/}OrderUpdateSubmit
+#   orderID - SOAP::SOAPInt
+#   newClientOrderIdentifier - SOAP::SOAPString
+#   flagStyle - SOAP::SOAPString
+#   flagDescription - SOAP::SOAPString
+#   transactionNotes - ChannelAdvisor::OrderServiceSOAP::TransactionNoteSubmit
+#   orderStatusUpdate - ChannelAdvisor::OrderServiceSOAP::OrderStatusUpdateSubmit
+#   billingInfo - ChannelAdvisor::OrderServiceSOAP::BillingInfoUpdateSubmit
+#   shippingInfo - ChannelAdvisor::OrderServiceSOAP::ShippingInfoUpdateSubmit
+#   paymentInfo - ChannelAdvisor::OrderServiceSOAP::PaymentInfoUpdateSubmit
+#   requestedShippingMethodInfo - ChannelAdvisor::OrderServiceSOAP::ShippingMethodInfoUpdateSubmit
+class OrderUpdateSubmit
+  attr_accessor :orderID
+  attr_accessor :newClientOrderIdentifier
+  attr_accessor :flagStyle
+  attr_accessor :flagDescription
+  attr_accessor :transactionNotes
+  attr_accessor :orderStatusUpdate
+  attr_accessor :billingInfo
+  attr_accessor :shippingInfo
+  attr_accessor :paymentInfo
+  attr_accessor :requestedShippingMethodInfo
+
+  def initialize(orderID = nil, newClientOrderIdentifier = nil, flagStyle = nil, flagDescription = nil, transactionNotes = nil, orderStatusUpdate = nil, billingInfo = nil, shippingInfo = nil, paymentInfo = nil, requestedShippingMethodInfo = nil)
+    @orderID = orderID
+    @newClientOrderIdentifier = newClientOrderIdentifier
+    @flagStyle = flagStyle
+    @flagDescription = flagDescription
+    @transactionNotes = transactionNotes
+    @orderStatusUpdate = orderStatusUpdate
+    @billingInfo = billingInfo
+    @shippingInfo = shippingInfo
+    @paymentInfo = paymentInfo
+    @requestedShippingMethodInfo = requestedShippingMethodInfo
+  end
+end
+
+# {http://api.channeladvisor.com/webservices/}TransactionNoteSubmit
+#   note - SOAP::SOAPString
+#   shouldOverwrite - SOAP::SOAPBoolean
+class TransactionNoteSubmit
+  attr_accessor :note
+  attr_accessor :shouldOverwrite
+
+  def initialize(note = nil, shouldOverwrite = nil)
+    @note = note
+    @shouldOverwrite = shouldOverwrite
+  end
+end
+
+# {http://api.channeladvisor.com/webservices/}OrderStatusUpdateSubmit
+#   checkoutPaymentStatus - SOAP::SOAPString
+#   shippingStatus - SOAP::SOAPString
+class OrderStatusUpdateSubmit
+  attr_accessor :checkoutPaymentStatus
+  attr_accessor :shippingStatus
+
+  def initialize(checkoutPaymentStatus = nil, shippingStatus = nil)
+    @checkoutPaymentStatus = checkoutPaymentStatus
+    @shippingStatus = shippingStatus
+  end
+end
+
+# {http://api.channeladvisor.com/webservices/}ShippingMethodInfoUpdateSubmit
+#   carrierCode - SOAP::SOAPString
+#   classCode - SOAP::SOAPString
+class ShippingMethodInfoUpdateSubmit
+  attr_accessor :carrierCode
+  attr_accessor :classCode
+
+  def initialize(carrierCode = nil, classCode = nil)
+    @carrierCode = carrierCode
+    @classCode = classCode
+  end
+end
+
+# {http://api.channeladvisor.com/webservices/}APIResultOfArrayOfOrderUpdateResponse
+#   status - ChannelAdvisor::OrderServiceSOAP::ResultStatus
+#   messageCode - SOAP::SOAPInt
+#   message - SOAP::SOAPString
+#   data - SOAP::SOAPString
+#   resultData - ChannelAdvisor::OrderServiceSOAP::ArrayOfOrderUpdateResponse
+class APIResultOfArrayOfOrderUpdateResponse
+  attr_accessor :status
+  attr_accessor :messageCode
+  attr_accessor :message
+  attr_accessor :data
+  attr_accessor :resultData
+
+  def initialize(status = nil, messageCode = nil, message = nil, data = nil, resultData = nil)
+    @status = status
+    @messageCode = messageCode
+    @message = message
+    @data = data
+    @resultData = resultData
+  end
+end
+
+# {http://api.channeladvisor.com/webservices/}ArrayOfOrderUpdateResponse
+class ArrayOfOrderUpdateResponse < ::Array
+end
+
+# {http://api.channeladvisor.com/webservices/}OrderUpdateResponse
+#   flagAndNotesSuccess - SOAP::SOAPBoolean
+#   flagAndNotesMessage - SOAP::SOAPString
+#   orderStatusSuccess - SOAP::SOAPBoolean
+#   orderStatusMessage - SOAP::SOAPString
+#   shippingAndCOIDSuccess - SOAP::SOAPBoolean
+#   shippingAndCOIDMessage - SOAP::SOAPString
+#   billingAndPaymentSuccess - SOAP::SOAPBoolean
+#   billingAndPaymentMessage - SOAP::SOAPString
+#   requestedShippingMethodSuccess - SOAP::SOAPBoolean
+#   requestedShippingMethodMessage - SOAP::SOAPString
+class OrderUpdateResponse
+  attr_accessor :flagAndNotesSuccess
+  attr_accessor :flagAndNotesMessage
+  attr_accessor :orderStatusSuccess
+  attr_accessor :orderStatusMessage
+  attr_accessor :shippingAndCOIDSuccess
+  attr_accessor :shippingAndCOIDMessage
+  attr_accessor :billingAndPaymentSuccess
+  attr_accessor :billingAndPaymentMessage
+  attr_accessor :requestedShippingMethodSuccess
+  attr_accessor :requestedShippingMethodMessage
+
+  def initialize(flagAndNotesSuccess = nil, flagAndNotesMessage = nil, orderStatusSuccess = nil, orderStatusMessage = nil, shippingAndCOIDSuccess = nil, shippingAndCOIDMessage = nil, billingAndPaymentSuccess = nil, billingAndPaymentMessage = nil, requestedShippingMethodSuccess = nil, requestedShippingMethodMessage = nil)
+    @flagAndNotesSuccess = flagAndNotesSuccess
+    @flagAndNotesMessage = flagAndNotesMessage
+    @orderStatusSuccess = orderStatusSuccess
+    @orderStatusMessage = orderStatusMessage
+    @shippingAndCOIDSuccess = shippingAndCOIDSuccess
+    @shippingAndCOIDMessage = shippingAndCOIDMessage
+    @billingAndPaymentSuccess = billingAndPaymentSuccess
+    @billingAndPaymentMessage = billingAndPaymentMessage
+    @requestedShippingMethodSuccess = requestedShippingMethodSuccess
+    @requestedShippingMethodMessage = requestedShippingMethodMessage
+  end
+end
+
+# {http://api.channeladvisor.com/webservices/}APIResultOfBoolean
+#   status - ChannelAdvisor::OrderServiceSOAP::ResultStatus
+#   messageCode - SOAP::SOAPInt
+#   message - SOAP::SOAPString
+#   data - SOAP::SOAPString
+#   resultData - SOAP::SOAPBoolean
+class APIResultOfBoolean
+  attr_accessor :status
+  attr_accessor :messageCode
+  attr_accessor :message
+  attr_accessor :data
+  attr_accessor :resultData
+
+  def initialize(status = nil, messageCode = nil, message = nil, data = nil, resultData = nil)
+    @status = status
+    @messageCode = messageCode
+    @message = message
+    @data = data
+    @resultData = resultData
+  end
+end
+
+# {http://api.channeladvisor.com/webservices/}APIResultOfInt32
+#   status - ChannelAdvisor::OrderServiceSOAP::ResultStatus
+#   messageCode - SOAP::SOAPInt
+#   message - SOAP::SOAPString
+#   data - SOAP::SOAPString
+#   resultData - SOAP::SOAPInt
+class APIResultOfInt32
   attr_accessor :status
   attr_accessor :messageCode
   attr_accessor :message
@@ -94,173 +371,6 @@ end
 class ArrayOfOrderResponseItem < ::Array
 end
 
-# {http://api.channeladvisor.com/webservices/}APIResultOfInt32
-#   status - ChannelAdvisor::OrderServiceSOAP::ResultStatus
-#   messageCode - SOAP::SOAPInt
-#   message - SOAP::SOAPString
-#   data - SOAP::SOAPString
-#   resultData - SOAP::SOAPInt
-class APIResultOfInt32
-  attr_accessor :status
-  attr_accessor :messageCode
-  attr_accessor :message
-  attr_accessor :data
-  attr_accessor :resultData
-
-  def initialize(status = nil, messageCode = nil, message = nil, data = nil, resultData = nil)
-    @status = status
-    @messageCode = messageCode
-    @message = message
-    @data = data
-    @resultData = resultData
-  end
-end
-
-# {http://api.channeladvisor.com/webservices/}ArrayOfInt
-class ArrayOfInt < ::Array
-end
-
-# {http://api.channeladvisor.com/webservices/}APIResultOfArrayOfInt32
-#   status - ChannelAdvisor::OrderServiceSOAP::ResultStatus
-#   messageCode - SOAP::SOAPInt
-#   message - SOAP::SOAPString
-#   data - SOAP::SOAPString
-#   resultData - ChannelAdvisor::OrderServiceSOAP::ArrayOfInt
-class APIResultOfArrayOfInt32
-  attr_accessor :status
-  attr_accessor :messageCode
-  attr_accessor :message
-  attr_accessor :data
-  attr_accessor :resultData
-
-  def initialize(status = nil, messageCode = nil, message = nil, data = nil, resultData = nil)
-    @status = status
-    @messageCode = messageCode
-    @message = message
-    @data = data
-    @resultData = resultData
-  end
-end
-
-# {http://api.channeladvisor.com/webservices/}APIResultOfOrderRefundHistoryResponse
-#   status - ChannelAdvisor::OrderServiceSOAP::ResultStatus
-#   messageCode - SOAP::SOAPInt
-#   message - SOAP::SOAPString
-#   data - SOAP::SOAPString
-#   resultData - ChannelAdvisor::OrderServiceSOAP::OrderRefundHistoryResponse
-class APIResultOfOrderRefundHistoryResponse
-  attr_accessor :status
-  attr_accessor :messageCode
-  attr_accessor :message
-  attr_accessor :data
-  attr_accessor :resultData
-
-  def initialize(status = nil, messageCode = nil, message = nil, data = nil, resultData = nil)
-    @status = status
-    @messageCode = messageCode
-    @message = message
-    @data = data
-    @resultData = resultData
-  end
-end
-
-# {http://api.channeladvisor.com/webservices/}ArrayOfOrderUpdateSubmit
-class ArrayOfOrderUpdateSubmit < ::Array
-end
-
-# {http://api.channeladvisor.com/webservices/}OrderUpdateSubmit
-#   orderID - SOAP::SOAPInt
-#   flagStyle - ChannelAdvisor::OrderServiceSOAP::FlagType
-#   flagDescription - SOAP::SOAPString
-#   transactionNotes - ChannelAdvisor::OrderServiceSOAP::TransactionNoteSubmit
-#   orderStatusUpdate - ChannelAdvisor::OrderServiceSOAP::OrderStatusUpdateSubmit
-class OrderUpdateSubmit
-  attr_accessor :orderID
-  attr_accessor :flagStyle
-  attr_accessor :flagDescription
-  attr_accessor :transactionNotes
-  attr_accessor :orderStatusUpdate
-
-  def initialize(orderID = nil, flagStyle = nil, flagDescription = nil, transactionNotes = nil, orderStatusUpdate = nil)
-    @orderID = orderID
-    @flagStyle = flagStyle
-    @flagDescription = flagDescription
-    @transactionNotes = transactionNotes
-    @orderStatusUpdate = orderStatusUpdate
-  end
-end
-
-# {http://api.channeladvisor.com/webservices/}TransactionNoteSubmit
-#   note - SOAP::SOAPString
-#   shouldOverwrite - SOAP::SOAPBoolean
-class TransactionNoteSubmit
-  attr_accessor :note
-  attr_accessor :shouldOverwrite
-
-  def initialize(note = nil, shouldOverwrite = nil)
-    @note = note
-    @shouldOverwrite = shouldOverwrite
-  end
-end
-
-# {http://api.channeladvisor.com/webservices/}OrderStatusUpdateSubmit
-#   checkoutPaymentStatus - ChannelAdvisor::OrderServiceSOAP::CheckoutPaymentStatusCode
-#   shippingStatus - ChannelAdvisor::OrderServiceSOAP::ShippingStatusCode
-class OrderStatusUpdateSubmit
-  attr_accessor :checkoutPaymentStatus
-  attr_accessor :shippingStatus
-
-  def initialize(checkoutPaymentStatus = nil, shippingStatus = nil)
-    @checkoutPaymentStatus = checkoutPaymentStatus
-    @shippingStatus = shippingStatus
-  end
-end
-
-# {http://api.channeladvisor.com/webservices/}APIResultOfArrayOfOrderUpdateResponse
-#   status - ChannelAdvisor::OrderServiceSOAP::ResultStatus
-#   messageCode - SOAP::SOAPInt
-#   message - SOAP::SOAPString
-#   data - SOAP::SOAPString
-#   resultData - ChannelAdvisor::OrderServiceSOAP::ArrayOfOrderUpdateResponse
-class APIResultOfArrayOfOrderUpdateResponse
-  attr_accessor :status
-  attr_accessor :messageCode
-  attr_accessor :message
-  attr_accessor :data
-  attr_accessor :resultData
-
-  def initialize(status = nil, messageCode = nil, message = nil, data = nil, resultData = nil)
-    @status = status
-    @messageCode = messageCode
-    @message = message
-    @data = data
-    @resultData = resultData
-  end
-end
-
-# {http://api.channeladvisor.com/webservices/}ArrayOfOrderUpdateResponse
-class ArrayOfOrderUpdateResponse < ::Array
-end
-
-# {http://api.channeladvisor.com/webservices/}OrderUpdateResponse
-#   flagAndNotesSuccess - SOAP::SOAPBoolean
-#   flagAndNotesMessage - SOAP::SOAPString
-#   orderStatusSuccess - SOAP::SOAPBoolean
-#   orderStatusMessage - SOAP::SOAPString
-class OrderUpdateResponse
-  attr_accessor :flagAndNotesSuccess
-  attr_accessor :flagAndNotesMessage
-  attr_accessor :orderStatusSuccess
-  attr_accessor :orderStatusMessage
-
-  def initialize(flagAndNotesSuccess = nil, flagAndNotesMessage = nil, orderStatusSuccess = nil, orderStatusMessage = nil)
-    @flagAndNotesSuccess = flagAndNotesSuccess
-    @flagAndNotesMessage = flagAndNotesMessage
-    @orderStatusSuccess = orderStatusSuccess
-    @orderStatusMessage = orderStatusMessage
-  end
-end
-
 # {http://api.channeladvisor.com/webservices/}APIResultOfString
 #   status - ChannelAdvisor::OrderServiceSOAP::ResultStatus
 #   messageCode - SOAP::SOAPInt
@@ -287,7 +397,7 @@ end
 #   clientOrderIdentifier - SOAP::SOAPString
 #   orderID - SOAP::SOAPInt
 #   amount - SOAP::SOAPDecimal
-#   adjustmentReason - ChannelAdvisor::OrderServiceSOAP::RefundAdjustmentReason
+#   adjustmentReason - SOAP::SOAPString
 #   sellerRefundID - SOAP::SOAPString
 #   refundItems - ChannelAdvisor::OrderServiceSOAP::ArrayOfRefundItem
 class RefundOrderRequest
@@ -320,12 +430,14 @@ end
 #   taxAmount - SOAP::SOAPDecimal
 #   giftWrapAmount - SOAP::SOAPDecimal
 #   giftWrapTaxAmount - SOAP::SOAPDecimal
+#   recyclingFee - SOAP::SOAPDecimal
 #   quantity - SOAP::SOAPInt
 #   refundRequestID - SOAP::SOAPInt
 #   refundRequested - SOAP::SOAPBoolean
 #   restockQuantity - SOAP::SOAPBoolean
-#   adjustmentReason - ChannelAdvisor::OrderServiceSOAP::RefundAdjustmentReason
+#   adjustmentReason - SOAP::SOAPString
 #   sellerRefundID - SOAP::SOAPString
+#   lineItemID - SOAP::SOAPInt
 class RefundItem
   attr_accessor :sKU
   attr_accessor :amount
@@ -334,14 +446,16 @@ class RefundItem
   attr_accessor :taxAmount
   attr_accessor :giftWrapAmount
   attr_accessor :giftWrapTaxAmount
+  attr_accessor :recyclingFee
   attr_accessor :quantity
   attr_accessor :refundRequestID
   attr_accessor :refundRequested
   attr_accessor :restockQuantity
   attr_accessor :adjustmentReason
   attr_accessor :sellerRefundID
+  attr_accessor :lineItemID
 
-  def initialize(sKU = nil, amount = nil, shippingAmount = nil, shippingTaxAmount = nil, taxAmount = nil, giftWrapAmount = nil, giftWrapTaxAmount = nil, quantity = nil, refundRequestID = nil, refundRequested = nil, restockQuantity = nil, adjustmentReason = nil, sellerRefundID = nil)
+  def initialize(sKU = nil, amount = nil, shippingAmount = nil, shippingTaxAmount = nil, taxAmount = nil, giftWrapAmount = nil, giftWrapTaxAmount = nil, recyclingFee = nil, quantity = nil, refundRequestID = nil, refundRequested = nil, restockQuantity = nil, adjustmentReason = nil, sellerRefundID = nil, lineItemID = nil)
     @sKU = sKU
     @amount = amount
     @shippingAmount = shippingAmount
@@ -349,12 +463,14 @@ class RefundItem
     @taxAmount = taxAmount
     @giftWrapAmount = giftWrapAmount
     @giftWrapTaxAmount = giftWrapTaxAmount
+    @recyclingFee = recyclingFee
     @quantity = quantity
     @refundRequestID = refundRequestID
     @refundRequested = refundRequested
     @restockQuantity = restockQuantity
     @adjustmentReason = adjustmentReason
     @sellerRefundID = sellerRefundID
+    @lineItemID = lineItemID
   end
 end
 
@@ -366,17 +482,19 @@ end
 #   taxAmount - SOAP::SOAPDecimal
 #   giftWrapAmount - SOAP::SOAPDecimal
 #   giftWrapTaxAmount - SOAP::SOAPDecimal
+#   recyclingFee - SOAP::SOAPDecimal
 #   quantity - SOAP::SOAPInt
 #   refundRequestID - SOAP::SOAPInt
 #   refundRequested - SOAP::SOAPBoolean
 #   restockQuantity - SOAP::SOAPBoolean
-#   adjustmentReason - ChannelAdvisor::OrderServiceSOAP::RefundAdjustmentReason
+#   adjustmentReason - SOAP::SOAPString
 #   sellerRefundID - SOAP::SOAPString
+#   lineItemID - SOAP::SOAPInt
 #   invoiceItemID - SOAP::SOAPInt
-#   itemSaleSource - ChannelAdvisor::OrderServiceSOAP::SiteToken
-#   refundRequestStatus - ChannelAdvisor::OrderServiceSOAP::AsyncStatusCode
+#   itemSaleSource - SOAP::SOAPString
+#   refundRequestStatus - SOAP::SOAPString
 #   refundPaymentInfo - ChannelAdvisor::OrderServiceSOAP::PaymentInfo
-#   restockStatus - ChannelAdvisor::OrderServiceSOAP::AsyncStatusCode
+#   restockStatus - SOAP::SOAPString
 #   refundCreateDateGMT - SOAP::SOAPDateTime
 class OrderLineItemRefundHistoryResponse < RefundItem
   attr_accessor :sKU
@@ -386,12 +504,14 @@ class OrderLineItemRefundHistoryResponse < RefundItem
   attr_accessor :taxAmount
   attr_accessor :giftWrapAmount
   attr_accessor :giftWrapTaxAmount
+  attr_accessor :recyclingFee
   attr_accessor :quantity
   attr_accessor :refundRequestID
   attr_accessor :refundRequested
   attr_accessor :restockQuantity
   attr_accessor :adjustmentReason
   attr_accessor :sellerRefundID
+  attr_accessor :lineItemID
   attr_accessor :invoiceItemID
   attr_accessor :itemSaleSource
   attr_accessor :refundRequestStatus
@@ -399,7 +519,7 @@ class OrderLineItemRefundHistoryResponse < RefundItem
   attr_accessor :restockStatus
   attr_accessor :refundCreateDateGMT
 
-  def initialize(sKU = nil, amount = nil, shippingAmount = nil, shippingTaxAmount = nil, taxAmount = nil, giftWrapAmount = nil, giftWrapTaxAmount = nil, quantity = nil, refundRequestID = nil, refundRequested = nil, restockQuantity = nil, adjustmentReason = nil, sellerRefundID = nil, invoiceItemID = nil, itemSaleSource = nil, refundRequestStatus = nil, refundPaymentInfo = nil, restockStatus = nil, refundCreateDateGMT = nil)
+  def initialize(sKU = nil, amount = nil, shippingAmount = nil, shippingTaxAmount = nil, taxAmount = nil, giftWrapAmount = nil, giftWrapTaxAmount = nil, recyclingFee = nil, quantity = nil, refundRequestID = nil, refundRequested = nil, restockQuantity = nil, adjustmentReason = nil, sellerRefundID = nil, lineItemID = nil, invoiceItemID = nil, itemSaleSource = nil, refundRequestStatus = nil, refundPaymentInfo = nil, restockStatus = nil, refundCreateDateGMT = nil)
     @sKU = sKU
     @amount = amount
     @shippingAmount = shippingAmount
@@ -407,12 +527,14 @@ class OrderLineItemRefundHistoryResponse < RefundItem
     @taxAmount = taxAmount
     @giftWrapAmount = giftWrapAmount
     @giftWrapTaxAmount = giftWrapTaxAmount
+    @recyclingFee = recyclingFee
     @quantity = quantity
     @refundRequestID = refundRequestID
     @refundRequested = refundRequested
     @restockQuantity = restockQuantity
     @adjustmentReason = adjustmentReason
     @sellerRefundID = sellerRefundID
+    @lineItemID = lineItemID
     @invoiceItemID = invoiceItemID
     @itemSaleSource = itemSaleSource
     @refundRequestStatus = refundRequestStatus
@@ -429,6 +551,28 @@ end
 #   merchantReferenceNumber - SOAP::SOAPString
 #   paymentTransactionID - SOAP::SOAPString
 class PaymentInfo
+  attr_accessor :paymentType
+  attr_accessor :creditCardLast4
+  attr_accessor :payPalID
+  attr_accessor :merchantReferenceNumber
+  attr_accessor :paymentTransactionID
+
+  def initialize(paymentType = nil, creditCardLast4 = nil, payPalID = nil, merchantReferenceNumber = nil, paymentTransactionID = nil)
+    @paymentType = paymentType
+    @creditCardLast4 = creditCardLast4
+    @payPalID = payPalID
+    @merchantReferenceNumber = merchantReferenceNumber
+    @paymentTransactionID = paymentTransactionID
+  end
+end
+
+# {http://api.channeladvisor.com/datacontracts/orders}PaymentInfoUpdateSubmit
+#   paymentType - SOAP::SOAPString
+#   creditCardLast4 - SOAP::SOAPString
+#   payPalID - SOAP::SOAPString
+#   merchantReferenceNumber - SOAP::SOAPString
+#   paymentTransactionID - SOAP::SOAPString
+class PaymentInfoUpdateSubmit < PaymentInfo
   attr_accessor :paymentType
   attr_accessor :creditCardLast4
   attr_accessor :payPalID
@@ -488,331 +632,565 @@ class RefundOrderResponse
   end
 end
 
-# {http://api.channeladvisor.com/datacontracts/orders}OrderCriteria
-#   orderCreationFilterBeginTimeGMT - SOAP::SOAPDateTime
-#   orderCreationFilterEndTimeGMT - SOAP::SOAPDateTime
-#   statusUpdateFilterBeginTimeGMT - SOAP::SOAPDateTime
-#   statusUpdateFilterEndTimeGMT - SOAP::SOAPDateTime
-#   joinDateFiltersWithOr - SOAP::SOAPBoolean
-#   detailLevel - ChannelAdvisor::OrderServiceSOAP::DetailLevelType
-#   exportState - ChannelAdvisor::OrderServiceSOAP::ExportStateType
-#   orderIDList - ChannelAdvisor::OrderServiceSOAP::ArrayOfInt_
-#   orderStateFilter - ChannelAdvisor::OrderServiceSOAP::OrderStateCode
-#   paymentStatusFilter - ChannelAdvisor::OrderServiceSOAP::PaymentStatusCode
-#   checkoutStatusFilter - ChannelAdvisor::OrderServiceSOAP::CheckoutStatusCode
-#   shippingStatusFilter - ChannelAdvisor::OrderServiceSOAP::ShippingStatusCode
-#   distributionCenterCode - SOAP::SOAPString
-#   pageNumberFilter - SOAP::SOAPInt
-#   pageSize - SOAP::SOAPInt
-class OrderCriteria
-  attr_accessor :orderCreationFilterBeginTimeGMT
-  attr_accessor :orderCreationFilterEndTimeGMT
-  attr_accessor :statusUpdateFilterBeginTimeGMT
-  attr_accessor :statusUpdateFilterEndTimeGMT
-  attr_accessor :joinDateFiltersWithOr
-  attr_accessor :detailLevel
-  attr_accessor :exportState
-  attr_accessor :orderIDList
-  attr_accessor :orderStateFilter
-  attr_accessor :paymentStatusFilter
-  attr_accessor :checkoutStatusFilter
-  attr_accessor :shippingStatusFilter
-  attr_accessor :distributionCenterCode
-  attr_accessor :pageNumberFilter
-  attr_accessor :pageSize
+# {http://api.channeladvisor.com/datacontracts/orders}OrderRefundHistoryResponse
+#   orderID - SOAP::SOAPInt
+#   clientOrderIdentifier - SOAP::SOAPString
+#   refundStatus - SOAP::SOAPString
+#   lineItemRefunds - ChannelAdvisor::OrderServiceSOAP::ArrayOfOrderLineItemRefundHistoryResponse
+class OrderRefundHistoryResponse
+  attr_accessor :orderID
+  attr_accessor :clientOrderIdentifier
+  attr_accessor :refundStatus
+  attr_accessor :lineItemRefunds
 
-  def initialize(orderCreationFilterBeginTimeGMT = nil, orderCreationFilterEndTimeGMT = nil, statusUpdateFilterBeginTimeGMT = nil, statusUpdateFilterEndTimeGMT = nil, joinDateFiltersWithOr = nil, detailLevel = nil, exportState = nil, orderIDList = nil, orderStateFilter = nil, paymentStatusFilter = nil, checkoutStatusFilter = nil, shippingStatusFilter = nil, distributionCenterCode = nil, pageNumberFilter = nil, pageSize = nil)
-    @orderCreationFilterBeginTimeGMT = orderCreationFilterBeginTimeGMT
-    @orderCreationFilterEndTimeGMT = orderCreationFilterEndTimeGMT
-    @statusUpdateFilterBeginTimeGMT = statusUpdateFilterBeginTimeGMT
-    @statusUpdateFilterEndTimeGMT = statusUpdateFilterEndTimeGMT
-    @joinDateFiltersWithOr = joinDateFiltersWithOr
-    @detailLevel = detailLevel
-    @exportState = exportState
-    @orderIDList = orderIDList
-    @orderStateFilter = orderStateFilter
-    @paymentStatusFilter = paymentStatusFilter
-    @checkoutStatusFilter = checkoutStatusFilter
-    @shippingStatusFilter = shippingStatusFilter
-    @distributionCenterCode = distributionCenterCode
-    @pageNumberFilter = pageNumberFilter
-    @pageSize = pageSize
+  def initialize(orderID = nil, clientOrderIdentifier = nil, refundStatus = nil, lineItemRefunds = nil)
+    @orderID = orderID
+    @clientOrderIdentifier = clientOrderIdentifier
+    @refundStatus = refundStatus
+    @lineItemRefunds = lineItemRefunds
   end
 end
 
-# {http://api.channeladvisor.com/datacontracts/orders}ArrayOfInt
-class ArrayOfInt_ < ::Array
+# {http://api.channeladvisor.com/datacontracts/orders}ArrayOfOrderLineItemRefundHistoryResponse
+class ArrayOfOrderLineItemRefundHistoryResponse < ::Array
 end
 
-# {http://api.channeladvisor.com/datacontracts/orders}OrderResponseItem
+# {http://api.channeladvisor.com/datacontracts/orders}AddressInfo
+#   addressLine1 - SOAP::SOAPString
+#   addressLine2 - SOAP::SOAPString
+#   city - SOAP::SOAPString
+#   region - SOAP::SOAPString
+#   regionDescription - SOAP::SOAPString
+#   postalCode - SOAP::SOAPString
+#   countryCode - SOAP::SOAPString
+class AddressInfo
+  attr_accessor :addressLine1
+  attr_accessor :addressLine2
+  attr_accessor :city
+  attr_accessor :region
+  attr_accessor :regionDescription
+  attr_accessor :postalCode
+  attr_accessor :countryCode
+
+  def initialize(addressLine1 = nil, addressLine2 = nil, city = nil, region = nil, regionDescription = nil, postalCode = nil, countryCode = nil)
+    @addressLine1 = addressLine1
+    @addressLine2 = addressLine2
+    @city = city
+    @region = region
+    @regionDescription = regionDescription
+    @postalCode = postalCode
+    @countryCode = countryCode
+  end
+end
+
+# {http://api.channeladvisor.com/datacontracts/orders}ContactComplete
+#   addressLine1 - SOAP::SOAPString
+#   addressLine2 - SOAP::SOAPString
+#   city - SOAP::SOAPString
+#   region - SOAP::SOAPString
+#   regionDescription - SOAP::SOAPString
+#   postalCode - SOAP::SOAPString
+#   countryCode - SOAP::SOAPString
+#   companyName - SOAP::SOAPString
+#   jobTitle - SOAP::SOAPString
+#   title - SOAP::SOAPString
+#   firstName - SOAP::SOAPString
+#   lastName - SOAP::SOAPString
+#   suffix - SOAP::SOAPString
+#   phoneNumberDay - SOAP::SOAPString
+#   phoneNumberEvening - SOAP::SOAPString
+class ContactComplete < AddressInfo
+  attr_accessor :addressLine1
+  attr_accessor :addressLine2
+  attr_accessor :city
+  attr_accessor :region
+  attr_accessor :regionDescription
+  attr_accessor :postalCode
+  attr_accessor :countryCode
+  attr_accessor :companyName
+  attr_accessor :jobTitle
+  attr_accessor :title
+  attr_accessor :firstName
+  attr_accessor :lastName
+  attr_accessor :suffix
+  attr_accessor :phoneNumberDay
+  attr_accessor :phoneNumberEvening
+
+  def initialize(addressLine1 = nil, addressLine2 = nil, city = nil, region = nil, regionDescription = nil, postalCode = nil, countryCode = nil, companyName = nil, jobTitle = nil, title = nil, firstName = nil, lastName = nil, suffix = nil, phoneNumberDay = nil, phoneNumberEvening = nil)
+    @addressLine1 = addressLine1
+    @addressLine2 = addressLine2
+    @city = city
+    @region = region
+    @regionDescription = regionDescription
+    @postalCode = postalCode
+    @countryCode = countryCode
+    @companyName = companyName
+    @jobTitle = jobTitle
+    @title = title
+    @firstName = firstName
+    @lastName = lastName
+    @suffix = suffix
+    @phoneNumberDay = phoneNumberDay
+    @phoneNumberEvening = phoneNumberEvening
+  end
+end
+
+# {http://api.channeladvisor.com/datacontracts/orders}BillingInfo
+#   addressLine1 - SOAP::SOAPString
+#   addressLine2 - SOAP::SOAPString
+#   city - SOAP::SOAPString
+#   region - SOAP::SOAPString
+#   regionDescription - SOAP::SOAPString
+#   postalCode - SOAP::SOAPString
+#   countryCode - SOAP::SOAPString
+#   companyName - SOAP::SOAPString
+#   jobTitle - SOAP::SOAPString
+#   title - SOAP::SOAPString
+#   firstName - SOAP::SOAPString
+#   lastName - SOAP::SOAPString
+#   suffix - SOAP::SOAPString
+#   phoneNumberDay - SOAP::SOAPString
+#   phoneNumberEvening - SOAP::SOAPString
+class BillingInfo < ContactComplete
+  attr_accessor :addressLine1
+  attr_accessor :addressLine2
+  attr_accessor :city
+  attr_accessor :region
+  attr_accessor :regionDescription
+  attr_accessor :postalCode
+  attr_accessor :countryCode
+  attr_accessor :companyName
+  attr_accessor :jobTitle
+  attr_accessor :title
+  attr_accessor :firstName
+  attr_accessor :lastName
+  attr_accessor :suffix
+  attr_accessor :phoneNumberDay
+  attr_accessor :phoneNumberEvening
+
+  def initialize(addressLine1 = nil, addressLine2 = nil, city = nil, region = nil, regionDescription = nil, postalCode = nil, countryCode = nil, companyName = nil, jobTitle = nil, title = nil, firstName = nil, lastName = nil, suffix = nil, phoneNumberDay = nil, phoneNumberEvening = nil)
+    @addressLine1 = addressLine1
+    @addressLine2 = addressLine2
+    @city = city
+    @region = region
+    @regionDescription = regionDescription
+    @postalCode = postalCode
+    @countryCode = countryCode
+    @companyName = companyName
+    @jobTitle = jobTitle
+    @title = title
+    @firstName = firstName
+    @lastName = lastName
+    @suffix = suffix
+    @phoneNumberDay = phoneNumberDay
+    @phoneNumberEvening = phoneNumberEvening
+  end
+end
+
+# {http://api.channeladvisor.com/datacontracts/orders}BillingInfoUpdateSubmit
+#   addressLine1 - SOAP::SOAPString
+#   addressLine2 - SOAP::SOAPString
+#   city - SOAP::SOAPString
+#   region - SOAP::SOAPString
+#   regionDescription - SOAP::SOAPString
+#   postalCode - SOAP::SOAPString
+#   countryCode - SOAP::SOAPString
+#   companyName - SOAP::SOAPString
+#   jobTitle - SOAP::SOAPString
+#   title - SOAP::SOAPString
+#   firstName - SOAP::SOAPString
+#   lastName - SOAP::SOAPString
+#   suffix - SOAP::SOAPString
+#   phoneNumberDay - SOAP::SOAPString
+#   phoneNumberEvening - SOAP::SOAPString
+#   emailAddress - SOAP::SOAPString
+class BillingInfoUpdateSubmit < BillingInfo
+  attr_accessor :addressLine1
+  attr_accessor :addressLine2
+  attr_accessor :city
+  attr_accessor :region
+  attr_accessor :regionDescription
+  attr_accessor :postalCode
+  attr_accessor :countryCode
+  attr_accessor :companyName
+  attr_accessor :jobTitle
+  attr_accessor :title
+  attr_accessor :firstName
+  attr_accessor :lastName
+  attr_accessor :suffix
+  attr_accessor :phoneNumberDay
+  attr_accessor :phoneNumberEvening
+  attr_accessor :emailAddress
+
+  def initialize(addressLine1 = nil, addressLine2 = nil, city = nil, region = nil, regionDescription = nil, postalCode = nil, countryCode = nil, companyName = nil, jobTitle = nil, title = nil, firstName = nil, lastName = nil, suffix = nil, phoneNumberDay = nil, phoneNumberEvening = nil, emailAddress = nil)
+    @addressLine1 = addressLine1
+    @addressLine2 = addressLine2
+    @city = city
+    @region = region
+    @regionDescription = regionDescription
+    @postalCode = postalCode
+    @countryCode = countryCode
+    @companyName = companyName
+    @jobTitle = jobTitle
+    @title = title
+    @firstName = firstName
+    @lastName = lastName
+    @suffix = suffix
+    @phoneNumberDay = phoneNumberDay
+    @phoneNumberEvening = phoneNumberEvening
+    @emailAddress = emailAddress
+  end
+end
+
+# {http://api.channeladvisor.com/datacontracts/orders}ShippingInfoUpdateSubmit
+#   addressLine1 - SOAP::SOAPString
+#   addressLine2 - SOAP::SOAPString
+#   city - SOAP::SOAPString
+#   region - SOAP::SOAPString
+#   regionDescription - SOAP::SOAPString
+#   postalCode - SOAP::SOAPString
+#   countryCode - SOAP::SOAPString
+#   companyName - SOAP::SOAPString
+#   jobTitle - SOAP::SOAPString
+#   title - SOAP::SOAPString
+#   firstName - SOAP::SOAPString
+#   lastName - SOAP::SOAPString
+#   suffix - SOAP::SOAPString
+#   phoneNumberDay - SOAP::SOAPString
+#   phoneNumberEvening - SOAP::SOAPString
+#   emailAddress - SOAP::SOAPString
+#   shippingInstructions - SOAP::SOAPString
+#   estimatedShipDate - SOAP::SOAPDateTime
+#   deliveryDate - SOAP::SOAPDateTime
+class ShippingInfoUpdateSubmit < ContactComplete
+  attr_accessor :addressLine1
+  attr_accessor :addressLine2
+  attr_accessor :city
+  attr_accessor :region
+  attr_accessor :regionDescription
+  attr_accessor :postalCode
+  attr_accessor :countryCode
+  attr_accessor :companyName
+  attr_accessor :jobTitle
+  attr_accessor :title
+  attr_accessor :firstName
+  attr_accessor :lastName
+  attr_accessor :suffix
+  attr_accessor :phoneNumberDay
+  attr_accessor :phoneNumberEvening
+  attr_accessor :emailAddress
+  attr_accessor :shippingInstructions
+  attr_accessor :estimatedShipDate
+  attr_accessor :deliveryDate
+
+  def initialize(addressLine1 = nil, addressLine2 = nil, city = nil, region = nil, regionDescription = nil, postalCode = nil, countryCode = nil, companyName = nil, jobTitle = nil, title = nil, firstName = nil, lastName = nil, suffix = nil, phoneNumberDay = nil, phoneNumberEvening = nil, emailAddress = nil, shippingInstructions = nil, estimatedShipDate = nil, deliveryDate = nil)
+    @addressLine1 = addressLine1
+    @addressLine2 = addressLine2
+    @city = city
+    @region = region
+    @regionDescription = regionDescription
+    @postalCode = postalCode
+    @countryCode = countryCode
+    @companyName = companyName
+    @jobTitle = jobTitle
+    @title = title
+    @firstName = firstName
+    @lastName = lastName
+    @suffix = suffix
+    @phoneNumberDay = phoneNumberDay
+    @phoneNumberEvening = phoneNumberEvening
+    @emailAddress = emailAddress
+    @shippingInstructions = shippingInstructions
+    @estimatedShipDate = estimatedShipDate
+    @deliveryDate = deliveryDate
+  end
+end
+
+# {http://api.channeladvisor.com/datacontracts/orders}ShippingInfo
 # abstract
-#   numberOfMatches - SOAP::SOAPInt
-#   orderTimeGMT - SOAP::SOAPDateTime
-#   lastUpdateDate - SOAP::SOAPDateTime
-#   totalOrderAmount - SOAP::SOAPDecimal
-#   orderState - ChannelAdvisor::OrderServiceSOAP::OrderStateCode
-#   dateCancelledGMT - SOAP::SOAPDateTime
-#   orderID - SOAP::SOAPInt
-#   clientOrderIdentifier - SOAP::SOAPString
-#   flagStyle - ChannelAdvisor::OrderServiceSOAP::FlagType
-class OrderResponseItem
-  attr_accessor :numberOfMatches
-  attr_accessor :orderTimeGMT
-  attr_accessor :lastUpdateDate
-  attr_accessor :totalOrderAmount
-  attr_accessor :orderState
-  attr_accessor :dateCancelledGMT
-  attr_accessor :orderID
-  attr_accessor :clientOrderIdentifier
-  attr_accessor :flagStyle
+#   addressLine1 - SOAP::SOAPString
+#   addressLine2 - SOAP::SOAPString
+#   city - SOAP::SOAPString
+#   region - SOAP::SOAPString
+#   regionDescription - SOAP::SOAPString
+#   postalCode - SOAP::SOAPString
+#   countryCode - SOAP::SOAPString
+#   companyName - SOAP::SOAPString
+#   jobTitle - SOAP::SOAPString
+#   title - SOAP::SOAPString
+#   firstName - SOAP::SOAPString
+#   lastName - SOAP::SOAPString
+#   suffix - SOAP::SOAPString
+#   phoneNumberDay - SOAP::SOAPString
+#   phoneNumberEvening - SOAP::SOAPString
+#   shipmentList - ChannelAdvisor::OrderServiceSOAP::ArrayOfShipment
+#   shippingInstructions - SOAP::SOAPString
+#   estimatedShipDate - SOAP::SOAPDateTime
+#   deliveryDate - SOAP::SOAPDateTime
+class ShippingInfo < ContactComplete
+  attr_accessor :addressLine1
+  attr_accessor :addressLine2
+  attr_accessor :city
+  attr_accessor :region
+  attr_accessor :regionDescription
+  attr_accessor :postalCode
+  attr_accessor :countryCode
+  attr_accessor :companyName
+  attr_accessor :jobTitle
+  attr_accessor :title
+  attr_accessor :firstName
+  attr_accessor :lastName
+  attr_accessor :suffix
+  attr_accessor :phoneNumberDay
+  attr_accessor :phoneNumberEvening
+  attr_accessor :shipmentList
+  attr_accessor :shippingInstructions
+  attr_accessor :estimatedShipDate
+  attr_accessor :deliveryDate
 
-  def initialize(numberOfMatches = nil, orderTimeGMT = nil, lastUpdateDate = nil, totalOrderAmount = nil, orderState = nil, dateCancelledGMT = nil, orderID = nil, clientOrderIdentifier = nil, flagStyle = nil)
-    @numberOfMatches = numberOfMatches
-    @orderTimeGMT = orderTimeGMT
-    @lastUpdateDate = lastUpdateDate
-    @totalOrderAmount = totalOrderAmount
-    @orderState = orderState
-    @dateCancelledGMT = dateCancelledGMT
-    @orderID = orderID
-    @clientOrderIdentifier = clientOrderIdentifier
-    @flagStyle = flagStyle
+  def initialize(addressLine1 = nil, addressLine2 = nil, city = nil, region = nil, regionDescription = nil, postalCode = nil, countryCode = nil, companyName = nil, jobTitle = nil, title = nil, firstName = nil, lastName = nil, suffix = nil, phoneNumberDay = nil, phoneNumberEvening = nil, shipmentList = nil, shippingInstructions = nil, estimatedShipDate = nil, deliveryDate = nil)
+    @addressLine1 = addressLine1
+    @addressLine2 = addressLine2
+    @city = city
+    @region = region
+    @regionDescription = regionDescription
+    @postalCode = postalCode
+    @countryCode = countryCode
+    @companyName = companyName
+    @jobTitle = jobTitle
+    @title = title
+    @firstName = firstName
+    @lastName = lastName
+    @suffix = suffix
+    @phoneNumberDay = phoneNumberDay
+    @phoneNumberEvening = phoneNumberEvening
+    @shipmentList = shipmentList
+    @shippingInstructions = shippingInstructions
+    @estimatedShipDate = estimatedShipDate
+    @deliveryDate = deliveryDate
   end
 end
 
-# {http://api.channeladvisor.com/datacontracts/orders}OrderResponseDetailLow
-#   numberOfMatches - SOAP::SOAPInt
-#   orderTimeGMT - SOAP::SOAPDateTime
-#   lastUpdateDate - SOAP::SOAPDateTime
-#   totalOrderAmount - SOAP::SOAPDecimal
-#   orderState - ChannelAdvisor::OrderServiceSOAP::OrderStateCode
-#   dateCancelledGMT - SOAP::SOAPDateTime
-#   orderID - SOAP::SOAPInt
-#   clientOrderIdentifier - SOAP::SOAPString
-#   flagStyle - ChannelAdvisor::OrderServiceSOAP::FlagType
-#   orderStatus - ChannelAdvisor::OrderServiceSOAP::OrderStatus
-class OrderResponseDetailLow < OrderResponseItem
-  attr_accessor :numberOfMatches
-  attr_accessor :orderTimeGMT
-  attr_accessor :lastUpdateDate
-  attr_accessor :totalOrderAmount
-  attr_accessor :orderState
-  attr_accessor :dateCancelledGMT
-  attr_accessor :orderID
-  attr_accessor :clientOrderIdentifier
-  attr_accessor :flagStyle
-  attr_accessor :orderStatus
+# {http://api.channeladvisor.com/datacontracts/orders}ShippingInfoSubmit
+#   addressLine1 - SOAP::SOAPString
+#   addressLine2 - SOAP::SOAPString
+#   city - SOAP::SOAPString
+#   region - SOAP::SOAPString
+#   regionDescription - SOAP::SOAPString
+#   postalCode - SOAP::SOAPString
+#   countryCode - SOAP::SOAPString
+#   companyName - SOAP::SOAPString
+#   jobTitle - SOAP::SOAPString
+#   title - SOAP::SOAPString
+#   firstName - SOAP::SOAPString
+#   lastName - SOAP::SOAPString
+#   suffix - SOAP::SOAPString
+#   phoneNumberDay - SOAP::SOAPString
+#   phoneNumberEvening - SOAP::SOAPString
+#   shipmentList - ChannelAdvisor::OrderServiceSOAP::ArrayOfShipment
+#   shippingInstructions - SOAP::SOAPString
+#   estimatedShipDate - SOAP::SOAPDateTime
+#   deliveryDate - SOAP::SOAPDateTime
+class ShippingInfoSubmit < ShippingInfo
+  attr_accessor :addressLine1
+  attr_accessor :addressLine2
+  attr_accessor :city
+  attr_accessor :region
+  attr_accessor :regionDescription
+  attr_accessor :postalCode
+  attr_accessor :countryCode
+  attr_accessor :companyName
+  attr_accessor :jobTitle
+  attr_accessor :title
+  attr_accessor :firstName
+  attr_accessor :lastName
+  attr_accessor :suffix
+  attr_accessor :phoneNumberDay
+  attr_accessor :phoneNumberEvening
+  attr_accessor :shipmentList
+  attr_accessor :shippingInstructions
+  attr_accessor :estimatedShipDate
+  attr_accessor :deliveryDate
 
-  def initialize(numberOfMatches = nil, orderTimeGMT = nil, lastUpdateDate = nil, totalOrderAmount = nil, orderState = nil, dateCancelledGMT = nil, orderID = nil, clientOrderIdentifier = nil, flagStyle = nil, orderStatus = nil)
-    @numberOfMatches = numberOfMatches
-    @orderTimeGMT = orderTimeGMT
-    @lastUpdateDate = lastUpdateDate
-    @totalOrderAmount = totalOrderAmount
-    @orderState = orderState
-    @dateCancelledGMT = dateCancelledGMT
-    @orderID = orderID
-    @clientOrderIdentifier = clientOrderIdentifier
-    @flagStyle = flagStyle
-    @orderStatus = orderStatus
+  def initialize(addressLine1 = nil, addressLine2 = nil, city = nil, region = nil, regionDescription = nil, postalCode = nil, countryCode = nil, companyName = nil, jobTitle = nil, title = nil, firstName = nil, lastName = nil, suffix = nil, phoneNumberDay = nil, phoneNumberEvening = nil, shipmentList = nil, shippingInstructions = nil, estimatedShipDate = nil, deliveryDate = nil)
+    @addressLine1 = addressLine1
+    @addressLine2 = addressLine2
+    @city = city
+    @region = region
+    @regionDescription = regionDescription
+    @postalCode = postalCode
+    @countryCode = countryCode
+    @companyName = companyName
+    @jobTitle = jobTitle
+    @title = title
+    @firstName = firstName
+    @lastName = lastName
+    @suffix = suffix
+    @phoneNumberDay = phoneNumberDay
+    @phoneNumberEvening = phoneNumberEvening
+    @shipmentList = shipmentList
+    @shippingInstructions = shippingInstructions
+    @estimatedShipDate = estimatedShipDate
+    @deliveryDate = deliveryDate
   end
 end
 
-# {http://api.channeladvisor.com/datacontracts/orders}OrderResponseDetailMedium
-#   numberOfMatches - SOAP::SOAPInt
+# {http://api.channeladvisor.com/datacontracts/orders}ShippingInfoResponse
+#   addressLine1 - SOAP::SOAPString
+#   addressLine2 - SOAP::SOAPString
+#   city - SOAP::SOAPString
+#   region - SOAP::SOAPString
+#   regionDescription - SOAP::SOAPString
+#   postalCode - SOAP::SOAPString
+#   countryCode - SOAP::SOAPString
+#   companyName - SOAP::SOAPString
+#   jobTitle - SOAP::SOAPString
+#   title - SOAP::SOAPString
+#   firstName - SOAP::SOAPString
+#   lastName - SOAP::SOAPString
+#   suffix - SOAP::SOAPString
+#   phoneNumberDay - SOAP::SOAPString
+#   phoneNumberEvening - SOAP::SOAPString
+#   shipmentList - ChannelAdvisor::OrderServiceSOAP::ArrayOfShipment
+#   shippingInstructions - SOAP::SOAPString
+#   estimatedShipDate - SOAP::SOAPDateTime
+#   deliveryDate - SOAP::SOAPDateTime
+class ShippingInfoResponse < ShippingInfo
+  attr_accessor :addressLine1
+  attr_accessor :addressLine2
+  attr_accessor :city
+  attr_accessor :region
+  attr_accessor :regionDescription
+  attr_accessor :postalCode
+  attr_accessor :countryCode
+  attr_accessor :companyName
+  attr_accessor :jobTitle
+  attr_accessor :title
+  attr_accessor :firstName
+  attr_accessor :lastName
+  attr_accessor :suffix
+  attr_accessor :phoneNumberDay
+  attr_accessor :phoneNumberEvening
+  attr_accessor :shipmentList
+  attr_accessor :shippingInstructions
+  attr_accessor :estimatedShipDate
+  attr_accessor :deliveryDate
+
+  def initialize(addressLine1 = nil, addressLine2 = nil, city = nil, region = nil, regionDescription = nil, postalCode = nil, countryCode = nil, companyName = nil, jobTitle = nil, title = nil, firstName = nil, lastName = nil, suffix = nil, phoneNumberDay = nil, phoneNumberEvening = nil, shipmentList = nil, shippingInstructions = nil, estimatedShipDate = nil, deliveryDate = nil)
+    @addressLine1 = addressLine1
+    @addressLine2 = addressLine2
+    @city = city
+    @region = region
+    @regionDescription = regionDescription
+    @postalCode = postalCode
+    @countryCode = countryCode
+    @companyName = companyName
+    @jobTitle = jobTitle
+    @title = title
+    @firstName = firstName
+    @lastName = lastName
+    @suffix = suffix
+    @phoneNumberDay = phoneNumberDay
+    @phoneNumberEvening = phoneNumberEvening
+    @shipmentList = shipmentList
+    @shippingInstructions = shippingInstructions
+    @estimatedShipDate = estimatedShipDate
+    @deliveryDate = deliveryDate
+  end
+end
+
+# {http://api.channeladvisor.com/datacontracts/orders}Order
+# abstract
 #   orderTimeGMT - SOAP::SOAPDateTime
-#   lastUpdateDate - SOAP::SOAPDateTime
-#   totalOrderAmount - SOAP::SOAPDecimal
-#   orderState - ChannelAdvisor::OrderServiceSOAP::OrderStateCode
-#   dateCancelledGMT - SOAP::SOAPDateTime
-#   orderID - SOAP::SOAPInt
 #   clientOrderIdentifier - SOAP::SOAPString
-#   flagStyle - ChannelAdvisor::OrderServiceSOAP::FlagType
+#   sellerOrderID - SOAP::SOAPString
 #   orderStatus - ChannelAdvisor::OrderServiceSOAP::OrderStatus
-#   resellerID - SOAP::SOAPString
 #   buyerEmailAddress - SOAP::SOAPString
 #   emailOptIn - SOAP::SOAPBoolean
-#   paymentInfo - ChannelAdvisor::OrderServiceSOAP::PaymentInfoResponse
-#   shippingInfo - ChannelAdvisor::OrderServiceSOAP::ShippingInfoResponse
-#   billingInfo - ChannelAdvisor::OrderServiceSOAP::BillingInfo
-#   flagDescription - SOAP::SOAPString
-class OrderResponseDetailMedium < OrderResponseDetailLow
-  attr_accessor :numberOfMatches
-  attr_accessor :orderTimeGMT
-  attr_accessor :lastUpdateDate
-  attr_accessor :totalOrderAmount
-  attr_accessor :orderState
-  attr_accessor :dateCancelledGMT
-  attr_accessor :orderID
-  attr_accessor :clientOrderIdentifier
-  attr_accessor :flagStyle
-  attr_accessor :orderStatus
-  attr_accessor :resellerID
-  attr_accessor :buyerEmailAddress
-  attr_accessor :emailOptIn
-  attr_accessor :paymentInfo
-  attr_accessor :shippingInfo
-  attr_accessor :billingInfo
-  attr_accessor :flagDescription
-
-  def initialize(numberOfMatches = nil, orderTimeGMT = nil, lastUpdateDate = nil, totalOrderAmount = nil, orderState = nil, dateCancelledGMT = nil, orderID = nil, clientOrderIdentifier = nil, flagStyle = nil, orderStatus = nil, resellerID = nil, buyerEmailAddress = nil, emailOptIn = nil, paymentInfo = nil, shippingInfo = nil, billingInfo = nil, flagDescription = nil)
-    @numberOfMatches = numberOfMatches
-    @orderTimeGMT = orderTimeGMT
-    @lastUpdateDate = lastUpdateDate
-    @totalOrderAmount = totalOrderAmount
-    @orderState = orderState
-    @dateCancelledGMT = dateCancelledGMT
-    @orderID = orderID
-    @clientOrderIdentifier = clientOrderIdentifier
-    @flagStyle = flagStyle
-    @orderStatus = orderStatus
-    @resellerID = resellerID
-    @buyerEmailAddress = buyerEmailAddress
-    @emailOptIn = emailOptIn
-    @paymentInfo = paymentInfo
-    @shippingInfo = shippingInfo
-    @billingInfo = billingInfo
-    @flagDescription = flagDescription
-  end
-end
-
-# {http://api.channeladvisor.com/datacontracts/orders}OrderResponseDetailHigh
-#   numberOfMatches - SOAP::SOAPInt
-#   orderTimeGMT - SOAP::SOAPDateTime
-#   lastUpdateDate - SOAP::SOAPDateTime
-#   totalOrderAmount - SOAP::SOAPDecimal
-#   orderState - ChannelAdvisor::OrderServiceSOAP::OrderStateCode
-#   dateCancelledGMT - SOAP::SOAPDateTime
-#   orderID - SOAP::SOAPInt
-#   clientOrderIdentifier - SOAP::SOAPString
-#   flagStyle - ChannelAdvisor::OrderServiceSOAP::FlagType
-#   orderStatus - ChannelAdvisor::OrderServiceSOAP::OrderStatus
 #   resellerID - SOAP::SOAPString
-#   buyerEmailAddress - SOAP::SOAPString
-#   emailOptIn - SOAP::SOAPBoolean
-#   paymentInfo - ChannelAdvisor::OrderServiceSOAP::PaymentInfoResponse
-#   shippingInfo - ChannelAdvisor::OrderServiceSOAP::ShippingInfoResponse
 #   billingInfo - ChannelAdvisor::OrderServiceSOAP::BillingInfo
-#   flagDescription - SOAP::SOAPString
-#   shoppingCart - ChannelAdvisor::OrderServiceSOAP::OrderCart
-class OrderResponseDetailHigh < OrderResponseDetailMedium
-  attr_accessor :numberOfMatches
-  attr_accessor :orderTimeGMT
-  attr_accessor :lastUpdateDate
-  attr_accessor :totalOrderAmount
-  attr_accessor :orderState
-  attr_accessor :dateCancelledGMT
-  attr_accessor :orderID
-  attr_accessor :clientOrderIdentifier
-  attr_accessor :flagStyle
-  attr_accessor :orderStatus
-  attr_accessor :resellerID
-  attr_accessor :buyerEmailAddress
-  attr_accessor :emailOptIn
-  attr_accessor :paymentInfo
-  attr_accessor :shippingInfo
-  attr_accessor :billingInfo
-  attr_accessor :flagDescription
-  attr_accessor :shoppingCart
-
-  def initialize(numberOfMatches = nil, orderTimeGMT = nil, lastUpdateDate = nil, totalOrderAmount = nil, orderState = nil, dateCancelledGMT = nil, orderID = nil, clientOrderIdentifier = nil, flagStyle = nil, orderStatus = nil, resellerID = nil, buyerEmailAddress = nil, emailOptIn = nil, paymentInfo = nil, shippingInfo = nil, billingInfo = nil, flagDescription = nil, shoppingCart = nil)
-    @numberOfMatches = numberOfMatches
-    @orderTimeGMT = orderTimeGMT
-    @lastUpdateDate = lastUpdateDate
-    @totalOrderAmount = totalOrderAmount
-    @orderState = orderState
-    @dateCancelledGMT = dateCancelledGMT
-    @orderID = orderID
-    @clientOrderIdentifier = clientOrderIdentifier
-    @flagStyle = flagStyle
-    @orderStatus = orderStatus
-    @resellerID = resellerID
-    @buyerEmailAddress = buyerEmailAddress
-    @emailOptIn = emailOptIn
-    @paymentInfo = paymentInfo
-    @shippingInfo = shippingInfo
-    @billingInfo = billingInfo
-    @flagDescription = flagDescription
-    @shoppingCart = shoppingCart
-  end
-end
-
-# {http://api.channeladvisor.com/datacontracts/orders}OrderResponseDetailComplete
-#   numberOfMatches - SOAP::SOAPInt
-#   orderTimeGMT - SOAP::SOAPDateTime
-#   lastUpdateDate - SOAP::SOAPDateTime
-#   totalOrderAmount - SOAP::SOAPDecimal
-#   orderState - ChannelAdvisor::OrderServiceSOAP::OrderStateCode
-#   dateCancelledGMT - SOAP::SOAPDateTime
-#   orderID - SOAP::SOAPInt
-#   clientOrderIdentifier - SOAP::SOAPString
-#   flagStyle - ChannelAdvisor::OrderServiceSOAP::FlagType
-#   orderStatus - ChannelAdvisor::OrderServiceSOAP::OrderStatus
-#   resellerID - SOAP::SOAPString
-#   buyerEmailAddress - SOAP::SOAPString
-#   emailOptIn - SOAP::SOAPBoolean
-#   paymentInfo - ChannelAdvisor::OrderServiceSOAP::PaymentInfoResponse
-#   shippingInfo - ChannelAdvisor::OrderServiceSOAP::ShippingInfoResponse
-#   billingInfo - ChannelAdvisor::OrderServiceSOAP::BillingInfo
-#   flagDescription - SOAP::SOAPString
+#   paymentInfo - ChannelAdvisor::OrderServiceSOAP::PaymentInfo
 #   shoppingCart - ChannelAdvisor::OrderServiceSOAP::OrderCart
 #   customValueList - ChannelAdvisor::OrderServiceSOAP::ArrayOfCustomValue
-#   buyerIpAddress - SOAP::SOAPString
-#   transactionNotes - SOAP::SOAPString
-class OrderResponseDetailComplete < OrderResponseDetailHigh
-  attr_accessor :numberOfMatches
+class Order
   attr_accessor :orderTimeGMT
-  attr_accessor :lastUpdateDate
-  attr_accessor :totalOrderAmount
-  attr_accessor :orderState
-  attr_accessor :dateCancelledGMT
-  attr_accessor :orderID
   attr_accessor :clientOrderIdentifier
-  attr_accessor :flagStyle
+  attr_accessor :sellerOrderID
   attr_accessor :orderStatus
-  attr_accessor :resellerID
   attr_accessor :buyerEmailAddress
   attr_accessor :emailOptIn
-  attr_accessor :paymentInfo
-  attr_accessor :shippingInfo
+  attr_accessor :resellerID
   attr_accessor :billingInfo
-  attr_accessor :flagDescription
+  attr_accessor :paymentInfo
   attr_accessor :shoppingCart
   attr_accessor :customValueList
-  attr_accessor :buyerIpAddress
-  attr_accessor :transactionNotes
 
-  def initialize(numberOfMatches = nil, orderTimeGMT = nil, lastUpdateDate = nil, totalOrderAmount = nil, orderState = nil, dateCancelledGMT = nil, orderID = nil, clientOrderIdentifier = nil, flagStyle = nil, orderStatus = nil, resellerID = nil, buyerEmailAddress = nil, emailOptIn = nil, paymentInfo = nil, shippingInfo = nil, billingInfo = nil, flagDescription = nil, shoppingCart = nil, customValueList = nil, buyerIpAddress = nil, transactionNotes = nil)
-    @numberOfMatches = numberOfMatches
+  def initialize(orderTimeGMT = nil, clientOrderIdentifier = nil, sellerOrderID = nil, orderStatus = nil, buyerEmailAddress = nil, emailOptIn = nil, resellerID = nil, billingInfo = nil, paymentInfo = nil, shoppingCart = nil, customValueList = nil)
     @orderTimeGMT = orderTimeGMT
-    @lastUpdateDate = lastUpdateDate
-    @totalOrderAmount = totalOrderAmount
-    @orderState = orderState
-    @dateCancelledGMT = dateCancelledGMT
-    @orderID = orderID
     @clientOrderIdentifier = clientOrderIdentifier
-    @flagStyle = flagStyle
+    @sellerOrderID = sellerOrderID
     @orderStatus = orderStatus
-    @resellerID = resellerID
     @buyerEmailAddress = buyerEmailAddress
     @emailOptIn = emailOptIn
-    @paymentInfo = paymentInfo
-    @shippingInfo = shippingInfo
+    @resellerID = resellerID
     @billingInfo = billingInfo
-    @flagDescription = flagDescription
+    @paymentInfo = paymentInfo
     @shoppingCart = shoppingCart
     @customValueList = customValueList
-    @buyerIpAddress = buyerIpAddress
-    @transactionNotes = transactionNotes
+  end
+end
+
+# {http://api.channeladvisor.com/datacontracts/orders}OrderSubmit
+#   orderTimeGMT - SOAP::SOAPDateTime
+#   clientOrderIdentifier - SOAP::SOAPString
+#   sellerOrderID - SOAP::SOAPString
+#   orderStatus - ChannelAdvisor::OrderServiceSOAP::OrderStatus
+#   buyerEmailAddress - SOAP::SOAPString
+#   emailOptIn - SOAP::SOAPBoolean
+#   resellerID - SOAP::SOAPString
+#   billingInfo - ChannelAdvisor::OrderServiceSOAP::BillingInfo
+#   paymentInfo - ChannelAdvisor::OrderServiceSOAP::PaymentInfo
+#   shoppingCart - ChannelAdvisor::OrderServiceSOAP::OrderCart
+#   customValueList - ChannelAdvisor::OrderServiceSOAP::ArrayOfCustomValue
+#   shippingInfo - ChannelAdvisor::OrderServiceSOAP::ShippingInfoSubmit
+class OrderSubmit < Order
+  attr_accessor :orderTimeGMT
+  attr_accessor :clientOrderIdentifier
+  attr_accessor :sellerOrderID
+  attr_accessor :orderStatus
+  attr_accessor :buyerEmailAddress
+  attr_accessor :emailOptIn
+  attr_accessor :resellerID
+  attr_accessor :billingInfo
+  attr_accessor :paymentInfo
+  attr_accessor :shoppingCart
+  attr_accessor :customValueList
+  attr_accessor :shippingInfo
+
+  def initialize(orderTimeGMT = nil, clientOrderIdentifier = nil, sellerOrderID = nil, orderStatus = nil, buyerEmailAddress = nil, emailOptIn = nil, resellerID = nil, billingInfo = nil, paymentInfo = nil, shoppingCart = nil, customValueList = nil, shippingInfo = nil)
+    @orderTimeGMT = orderTimeGMT
+    @clientOrderIdentifier = clientOrderIdentifier
+    @sellerOrderID = sellerOrderID
+    @orderStatus = orderStatus
+    @buyerEmailAddress = buyerEmailAddress
+    @emailOptIn = emailOptIn
+    @resellerID = resellerID
+    @billingInfo = billingInfo
+    @paymentInfo = paymentInfo
+    @shoppingCart = shoppingCart
+    @customValueList = customValueList
+    @shippingInfo = shippingInfo
   end
 end
 
 # {http://api.channeladvisor.com/datacontracts/orders}OrderStatus
-#   checkoutStatus - ChannelAdvisor::OrderServiceSOAP::CheckoutStatusCode
+#   checkoutStatus - SOAP::SOAPString
 #   checkoutDateGMT - SOAP::SOAPDateTime
-#   paymentStatus - ChannelAdvisor::OrderServiceSOAP::PaymentStatusCode
+#   paymentStatus - SOAP::SOAPString
 #   paymentDateGMT - SOAP::SOAPDateTime
-#   shippingStatus - ChannelAdvisor::OrderServiceSOAP::ShippingStatusCode
+#   shippingStatus - SOAP::SOAPString
 #   shippingDateGMT - SOAP::SOAPDateTime
-#   orderRefundStatus - ChannelAdvisor::OrderServiceSOAP::OrderRefundStatusCode
+#   orderRefundStatus - SOAP::SOAPString
 class OrderStatus
   attr_accessor :checkoutStatus
   attr_accessor :checkoutDateGMT
@@ -833,321 +1211,12 @@ class OrderStatus
   end
 end
 
-# {http://api.channeladvisor.com/datacontracts/orders}AddressInfo
-#   addressLine1 - SOAP::SOAPString
-#   addressLine2 - SOAP::SOAPString
-#   city - SOAP::SOAPString
-#   region - SOAP::SOAPString
-#   postalCode - SOAP::SOAPString
-#   countryCode - SOAP::SOAPString
-class AddressInfo
-  attr_accessor :addressLine1
-  attr_accessor :addressLine2
-  attr_accessor :city
-  attr_accessor :region
-  attr_accessor :postalCode
-  attr_accessor :countryCode
-
-  def initialize(addressLine1 = nil, addressLine2 = nil, city = nil, region = nil, postalCode = nil, countryCode = nil)
-    @addressLine1 = addressLine1
-    @addressLine2 = addressLine2
-    @city = city
-    @region = region
-    @postalCode = postalCode
-    @countryCode = countryCode
-  end
-end
-
-# {http://api.channeladvisor.com/datacontracts/orders}ContactComplete
-#   addressLine1 - SOAP::SOAPString
-#   addressLine2 - SOAP::SOAPString
-#   city - SOAP::SOAPString
-#   region - SOAP::SOAPString
-#   postalCode - SOAP::SOAPString
-#   countryCode - SOAP::SOAPString
-#   companyName - SOAP::SOAPString
-#   jobTitle - SOAP::SOAPString
-#   title - SOAP::SOAPString
-#   firstName - SOAP::SOAPString
-#   lastName - SOAP::SOAPString
-#   suffix - SOAP::SOAPString
-#   phoneNumberDay - SOAP::SOAPString
-#   phoneNumberEvening - SOAP::SOAPString
-class ContactComplete < AddressInfo
-  attr_accessor :addressLine1
-  attr_accessor :addressLine2
-  attr_accessor :city
-  attr_accessor :region
-  attr_accessor :postalCode
-  attr_accessor :countryCode
-  attr_accessor :companyName
-  attr_accessor :jobTitle
-  attr_accessor :title
-  attr_accessor :firstName
-  attr_accessor :lastName
-  attr_accessor :suffix
-  attr_accessor :phoneNumberDay
-  attr_accessor :phoneNumberEvening
-
-  def initialize(addressLine1 = nil, addressLine2 = nil, city = nil, region = nil, postalCode = nil, countryCode = nil, companyName = nil, jobTitle = nil, title = nil, firstName = nil, lastName = nil, suffix = nil, phoneNumberDay = nil, phoneNumberEvening = nil)
-    @addressLine1 = addressLine1
-    @addressLine2 = addressLine2
-    @city = city
-    @region = region
-    @postalCode = postalCode
-    @countryCode = countryCode
-    @companyName = companyName
-    @jobTitle = jobTitle
-    @title = title
-    @firstName = firstName
-    @lastName = lastName
-    @suffix = suffix
-    @phoneNumberDay = phoneNumberDay
-    @phoneNumberEvening = phoneNumberEvening
-  end
-end
-
-# {http://api.channeladvisor.com/datacontracts/orders}ShippingInfo
-# abstract
-#   addressLine1 - SOAP::SOAPString
-#   addressLine2 - SOAP::SOAPString
-#   city - SOAP::SOAPString
-#   region - SOAP::SOAPString
-#   postalCode - SOAP::SOAPString
-#   countryCode - SOAP::SOAPString
-#   companyName - SOAP::SOAPString
-#   jobTitle - SOAP::SOAPString
-#   title - SOAP::SOAPString
-#   firstName - SOAP::SOAPString
-#   lastName - SOAP::SOAPString
-#   suffix - SOAP::SOAPString
-#   phoneNumberDay - SOAP::SOAPString
-#   phoneNumberEvening - SOAP::SOAPString
-#   shipmentList - ChannelAdvisor::OrderServiceSOAP::ArrayOfShipment
-#   shippingInstructions - SOAP::SOAPString
-class ShippingInfo < ContactComplete
-  attr_accessor :addressLine1
-  attr_accessor :addressLine2
-  attr_accessor :city
-  attr_accessor :region
-  attr_accessor :postalCode
-  attr_accessor :countryCode
-  attr_accessor :companyName
-  attr_accessor :jobTitle
-  attr_accessor :title
-  attr_accessor :firstName
-  attr_accessor :lastName
-  attr_accessor :suffix
-  attr_accessor :phoneNumberDay
-  attr_accessor :phoneNumberEvening
-  attr_accessor :shipmentList
-  attr_accessor :shippingInstructions
-
-  def initialize(addressLine1 = nil, addressLine2 = nil, city = nil, region = nil, postalCode = nil, countryCode = nil, companyName = nil, jobTitle = nil, title = nil, firstName = nil, lastName = nil, suffix = nil, phoneNumberDay = nil, phoneNumberEvening = nil, shipmentList = nil, shippingInstructions = nil)
-    @addressLine1 = addressLine1
-    @addressLine2 = addressLine2
-    @city = city
-    @region = region
-    @postalCode = postalCode
-    @countryCode = countryCode
-    @companyName = companyName
-    @jobTitle = jobTitle
-    @title = title
-    @firstName = firstName
-    @lastName = lastName
-    @suffix = suffix
-    @phoneNumberDay = phoneNumberDay
-    @phoneNumberEvening = phoneNumberEvening
-    @shipmentList = shipmentList
-    @shippingInstructions = shippingInstructions
-  end
-end
-
-# {http://api.channeladvisor.com/datacontracts/orders}ShippingInfoResponse
-#   addressLine1 - SOAP::SOAPString
-#   addressLine2 - SOAP::SOAPString
-#   city - SOAP::SOAPString
-#   region - SOAP::SOAPString
-#   postalCode - SOAP::SOAPString
-#   countryCode - SOAP::SOAPString
-#   companyName - SOAP::SOAPString
-#   jobTitle - SOAP::SOAPString
-#   title - SOAP::SOAPString
-#   firstName - SOAP::SOAPString
-#   lastName - SOAP::SOAPString
-#   suffix - SOAP::SOAPString
-#   phoneNumberDay - SOAP::SOAPString
-#   phoneNumberEvening - SOAP::SOAPString
-#   shipmentList - ChannelAdvisor::OrderServiceSOAP::ArrayOfShipment
-#   shippingInstructions - SOAP::SOAPString
-class ShippingInfoResponse < ShippingInfo
-  attr_accessor :addressLine1
-  attr_accessor :addressLine2
-  attr_accessor :city
-  attr_accessor :region
-  attr_accessor :postalCode
-  attr_accessor :countryCode
-  attr_accessor :companyName
-  attr_accessor :jobTitle
-  attr_accessor :title
-  attr_accessor :firstName
-  attr_accessor :lastName
-  attr_accessor :suffix
-  attr_accessor :phoneNumberDay
-  attr_accessor :phoneNumberEvening
-  attr_accessor :shipmentList
-  attr_accessor :shippingInstructions
-
-  def initialize(addressLine1 = nil, addressLine2 = nil, city = nil, region = nil, postalCode = nil, countryCode = nil, companyName = nil, jobTitle = nil, title = nil, firstName = nil, lastName = nil, suffix = nil, phoneNumberDay = nil, phoneNumberEvening = nil, shipmentList = nil, shippingInstructions = nil)
-    @addressLine1 = addressLine1
-    @addressLine2 = addressLine2
-    @city = city
-    @region = region
-    @postalCode = postalCode
-    @countryCode = countryCode
-    @companyName = companyName
-    @jobTitle = jobTitle
-    @title = title
-    @firstName = firstName
-    @lastName = lastName
-    @suffix = suffix
-    @phoneNumberDay = phoneNumberDay
-    @phoneNumberEvening = phoneNumberEvening
-    @shipmentList = shipmentList
-    @shippingInstructions = shippingInstructions
-  end
-end
-
-# {http://api.channeladvisor.com/datacontracts/orders}ShippingInfoSubmit
-#   addressLine1 - SOAP::SOAPString
-#   addressLine2 - SOAP::SOAPString
-#   city - SOAP::SOAPString
-#   region - SOAP::SOAPString
-#   postalCode - SOAP::SOAPString
-#   countryCode - SOAP::SOAPString
-#   companyName - SOAP::SOAPString
-#   jobTitle - SOAP::SOAPString
-#   title - SOAP::SOAPString
-#   firstName - SOAP::SOAPString
-#   lastName - SOAP::SOAPString
-#   suffix - SOAP::SOAPString
-#   phoneNumberDay - SOAP::SOAPString
-#   phoneNumberEvening - SOAP::SOAPString
-#   shipmentList - ChannelAdvisor::OrderServiceSOAP::ArrayOfShipment
-#   shippingInstructions - SOAP::SOAPString
-class ShippingInfoSubmit < ShippingInfo
-  attr_accessor :addressLine1
-  attr_accessor :addressLine2
-  attr_accessor :city
-  attr_accessor :region
-  attr_accessor :postalCode
-  attr_accessor :countryCode
-  attr_accessor :companyName
-  attr_accessor :jobTitle
-  attr_accessor :title
-  attr_accessor :firstName
-  attr_accessor :lastName
-  attr_accessor :suffix
-  attr_accessor :phoneNumberDay
-  attr_accessor :phoneNumberEvening
-  attr_accessor :shipmentList
-  attr_accessor :shippingInstructions
-
-  def initialize(addressLine1 = nil, addressLine2 = nil, city = nil, region = nil, postalCode = nil, countryCode = nil, companyName = nil, jobTitle = nil, title = nil, firstName = nil, lastName = nil, suffix = nil, phoneNumberDay = nil, phoneNumberEvening = nil, shipmentList = nil, shippingInstructions = nil)
-    @addressLine1 = addressLine1
-    @addressLine2 = addressLine2
-    @city = city
-    @region = region
-    @postalCode = postalCode
-    @countryCode = countryCode
-    @companyName = companyName
-    @jobTitle = jobTitle
-    @title = title
-    @firstName = firstName
-    @lastName = lastName
-    @suffix = suffix
-    @phoneNumberDay = phoneNumberDay
-    @phoneNumberEvening = phoneNumberEvening
-    @shipmentList = shipmentList
-    @shippingInstructions = shippingInstructions
-  end
-end
-
-# {http://api.channeladvisor.com/datacontracts/orders}BillingInfo
-#   addressLine1 - SOAP::SOAPString
-#   addressLine2 - SOAP::SOAPString
-#   city - SOAP::SOAPString
-#   region - SOAP::SOAPString
-#   postalCode - SOAP::SOAPString
-#   countryCode - SOAP::SOAPString
-#   companyName - SOAP::SOAPString
-#   jobTitle - SOAP::SOAPString
-#   title - SOAP::SOAPString
-#   firstName - SOAP::SOAPString
-#   lastName - SOAP::SOAPString
-#   suffix - SOAP::SOAPString
-#   phoneNumberDay - SOAP::SOAPString
-#   phoneNumberEvening - SOAP::SOAPString
-class BillingInfo < ContactComplete
-  attr_accessor :addressLine1
-  attr_accessor :addressLine2
-  attr_accessor :city
-  attr_accessor :region
-  attr_accessor :postalCode
-  attr_accessor :countryCode
-  attr_accessor :companyName
-  attr_accessor :jobTitle
-  attr_accessor :title
-  attr_accessor :firstName
-  attr_accessor :lastName
-  attr_accessor :suffix
-  attr_accessor :phoneNumberDay
-  attr_accessor :phoneNumberEvening
-
-  def initialize(addressLine1 = nil, addressLine2 = nil, city = nil, region = nil, postalCode = nil, countryCode = nil, companyName = nil, jobTitle = nil, title = nil, firstName = nil, lastName = nil, suffix = nil, phoneNumberDay = nil, phoneNumberEvening = nil)
-    @addressLine1 = addressLine1
-    @addressLine2 = addressLine2
-    @city = city
-    @region = region
-    @postalCode = postalCode
-    @countryCode = countryCode
-    @companyName = companyName
-    @jobTitle = jobTitle
-    @title = title
-    @firstName = firstName
-    @lastName = lastName
-    @suffix = suffix
-    @phoneNumberDay = phoneNumberDay
-    @phoneNumberEvening = phoneNumberEvening
-  end
-end
-
-# {http://api.channeladvisor.com/datacontracts/orders}ArrayOfShipment
-class ArrayOfShipment < ::Array
-end
-
-# {http://api.channeladvisor.com/datacontracts/orders}Shipment
-#   shippingCarrier - SOAP::SOAPString
-#   shippingClass - SOAP::SOAPString
-#   trackingNumber - SOAP::SOAPString
-class Shipment
-  attr_accessor :shippingCarrier
-  attr_accessor :shippingClass
-  attr_accessor :trackingNumber
-
-  def initialize(shippingCarrier = nil, shippingClass = nil, trackingNumber = nil)
-    @shippingCarrier = shippingCarrier
-    @shippingClass = shippingClass
-    @trackingNumber = trackingNumber
-  end
-end
-
 # {http://api.channeladvisor.com/datacontracts/orders}OrderCart
 #   cartID - SOAP::SOAPInt
-#   checkoutSource - ChannelAdvisor::OrderServiceSOAP::CheckoutSourceType
-#   vATTaxCalculationOption - ChannelAdvisor::OrderServiceSOAP::VAT_Calculation_Type
-#   vATShippingOption - ChannelAdvisor::OrderServiceSOAP::VAT_Calculation_Type
-#   vATGiftWrapOption - ChannelAdvisor::OrderServiceSOAP::VAT_Calculation_Type
+#   checkoutSource - SOAP::SOAPString
+#   vATTaxCalculationOption - SOAP::SOAPString
+#   vATShippingOption - SOAP::SOAPString
+#   vATGiftWrapOption - SOAP::SOAPString
 #   lineItemSKUList - ChannelAdvisor::OrderServiceSOAP::ArrayOfOrderLineItemItem
 #   lineItemInvoiceList - ChannelAdvisor::OrderServiceSOAP::ArrayOfOrderLineItemInvoice
 #   lineItemPromoList - ChannelAdvisor::OrderServiceSOAP::ArrayOfOrderLineItemPromo
@@ -1179,7 +1248,7 @@ end
 
 # {http://api.channeladvisor.com/datacontracts/orders}OrderLineItemBase
 # abstract
-#   lineItemType - ChannelAdvisor::OrderServiceSOAP::LineItemTypeCode
+#   lineItemType - SOAP::SOAPString
 #   unitPrice - SOAP::SOAPDecimal
 class OrderLineItemBase
   attr_accessor :lineItemType
@@ -1192,12 +1261,12 @@ class OrderLineItemBase
 end
 
 # {http://api.channeladvisor.com/datacontracts/orders}OrderLineItemItem
-#   lineItemType - ChannelAdvisor::OrderServiceSOAP::LineItemTypeCode
+#   lineItemType - SOAP::SOAPString
 #   unitPrice - SOAP::SOAPDecimal
 #   lineItemID - SOAP::SOAPInt
 #   allowNegativeQuantity - SOAP::SOAPBoolean
 #   quantity - SOAP::SOAPInt
-#   itemSaleSource - ChannelAdvisor::OrderServiceSOAP::SiteToken
+#   itemSaleSource - SOAP::SOAPString
 #   sKU - SOAP::SOAPString
 #   title - SOAP::SOAPString
 #   buyerUserID - SOAP::SOAPString
@@ -1212,6 +1281,8 @@ end
 #   giftMessage - SOAP::SOAPString
 #   giftWrapLevel - SOAP::SOAPString
 #   itemPromoList - ChannelAdvisor::OrderServiceSOAP::ArrayOfOrderLineItemItemPromo
+#   recyclingFee - SOAP::SOAPDecimal
+#   fulfillmentType - SOAP::SOAPString
 class OrderLineItemItem < OrderLineItemBase
   attr_accessor :lineItemType
   attr_accessor :unitPrice
@@ -1233,8 +1304,10 @@ class OrderLineItemItem < OrderLineItemBase
   attr_accessor :giftMessage
   attr_accessor :giftWrapLevel
   attr_accessor :itemPromoList
+  attr_accessor :recyclingFee
+  attr_accessor :fulfillmentType
 
-  def initialize(lineItemType = nil, unitPrice = nil, lineItemID = nil, allowNegativeQuantity = nil, quantity = nil, itemSaleSource = nil, sKU = nil, title = nil, buyerUserID = nil, buyerFeedbackRating = nil, salesSourceID = nil, vATRate = nil, taxCost = nil, shippingCost = nil, shippingTaxCost = nil, giftWrapCost = nil, giftWrapTaxCost = nil, giftMessage = nil, giftWrapLevel = nil, itemPromoList = nil)
+  def initialize(lineItemType = nil, unitPrice = nil, lineItemID = nil, allowNegativeQuantity = nil, quantity = nil, itemSaleSource = nil, sKU = nil, title = nil, buyerUserID = nil, buyerFeedbackRating = nil, salesSourceID = nil, vATRate = nil, taxCost = nil, shippingCost = nil, shippingTaxCost = nil, giftWrapCost = nil, giftWrapTaxCost = nil, giftMessage = nil, giftWrapLevel = nil, itemPromoList = nil, recyclingFee = nil, fulfillmentType = nil)
     @lineItemType = lineItemType
     @unitPrice = unitPrice
     @lineItemID = lineItemID
@@ -1255,16 +1328,18 @@ class OrderLineItemItem < OrderLineItemBase
     @giftMessage = giftMessage
     @giftWrapLevel = giftWrapLevel
     @itemPromoList = itemPromoList
+    @recyclingFee = recyclingFee
+    @fulfillmentType = fulfillmentType
   end
 end
 
 # {http://api.channeladvisor.com/datacontracts/orders}OrderLineItemItemResponse
-#   lineItemType - ChannelAdvisor::OrderServiceSOAP::LineItemTypeCode
+#   lineItemType - SOAP::SOAPString
 #   unitPrice - SOAP::SOAPDecimal
 #   lineItemID - SOAP::SOAPInt
 #   allowNegativeQuantity - SOAP::SOAPBoolean
 #   quantity - SOAP::SOAPInt
-#   itemSaleSource - ChannelAdvisor::OrderServiceSOAP::SiteToken
+#   itemSaleSource - SOAP::SOAPString
 #   sKU - SOAP::SOAPString
 #   title - SOAP::SOAPString
 #   buyerUserID - SOAP::SOAPString
@@ -1279,10 +1354,14 @@ end
 #   giftMessage - SOAP::SOAPString
 #   giftWrapLevel - SOAP::SOAPString
 #   itemPromoList - ChannelAdvisor::OrderServiceSOAP::ArrayOfOrderLineItemItemPromo
+#   recyclingFee - SOAP::SOAPDecimal
+#   fulfillmentType - SOAP::SOAPString
 #   unitWeight - ChannelAdvisor::OrderServiceSOAP::ItemWeight
 #   warehouseLocation - SOAP::SOAPString
 #   userName - SOAP::SOAPString
 #   distributionCenterCode - SOAP::SOAPString
+#   isExternallyFulfilled - SOAP::SOAPBoolean
+#   itemSaleSourceTransactionID - SOAP::SOAPString
 class OrderLineItemItemResponse < OrderLineItemItem
   attr_accessor :lineItemType
   attr_accessor :unitPrice
@@ -1304,12 +1383,16 @@ class OrderLineItemItemResponse < OrderLineItemItem
   attr_accessor :giftMessage
   attr_accessor :giftWrapLevel
   attr_accessor :itemPromoList
+  attr_accessor :recyclingFee
+  attr_accessor :fulfillmentType
   attr_accessor :unitWeight
   attr_accessor :warehouseLocation
   attr_accessor :userName
   attr_accessor :distributionCenterCode
+  attr_accessor :isExternallyFulfilled
+  attr_accessor :itemSaleSourceTransactionID
 
-  def initialize(lineItemType = nil, unitPrice = nil, lineItemID = nil, allowNegativeQuantity = nil, quantity = nil, itemSaleSource = nil, sKU = nil, title = nil, buyerUserID = nil, buyerFeedbackRating = nil, salesSourceID = nil, vATRate = nil, taxCost = nil, shippingCost = nil, shippingTaxCost = nil, giftWrapCost = nil, giftWrapTaxCost = nil, giftMessage = nil, giftWrapLevel = nil, itemPromoList = nil, unitWeight = nil, warehouseLocation = nil, userName = nil, distributionCenterCode = nil)
+  def initialize(lineItemType = nil, unitPrice = nil, lineItemID = nil, allowNegativeQuantity = nil, quantity = nil, itemSaleSource = nil, sKU = nil, title = nil, buyerUserID = nil, buyerFeedbackRating = nil, salesSourceID = nil, vATRate = nil, taxCost = nil, shippingCost = nil, shippingTaxCost = nil, giftWrapCost = nil, giftWrapTaxCost = nil, giftMessage = nil, giftWrapLevel = nil, itemPromoList = nil, recyclingFee = nil, fulfillmentType = nil, unitWeight = nil, warehouseLocation = nil, userName = nil, distributionCenterCode = nil, isExternallyFulfilled = nil, itemSaleSourceTransactionID = nil)
     @lineItemType = lineItemType
     @unitPrice = unitPrice
     @lineItemID = lineItemID
@@ -1330,15 +1413,19 @@ class OrderLineItemItemResponse < OrderLineItemItem
     @giftMessage = giftMessage
     @giftWrapLevel = giftWrapLevel
     @itemPromoList = itemPromoList
+    @recyclingFee = recyclingFee
+    @fulfillmentType = fulfillmentType
     @unitWeight = unitWeight
     @warehouseLocation = warehouseLocation
     @userName = userName
     @distributionCenterCode = distributionCenterCode
+    @isExternallyFulfilled = isExternallyFulfilled
+    @itemSaleSourceTransactionID = itemSaleSourceTransactionID
   end
 end
 
 # {http://api.channeladvisor.com/datacontracts/orders}OrderLineItemPromo
-#   lineItemType - ChannelAdvisor::OrderServiceSOAP::LineItemTypeCode
+#   lineItemType - SOAP::SOAPString
 #   unitPrice - SOAP::SOAPDecimal
 #   promoCode - SOAP::SOAPString
 class OrderLineItemPromo < OrderLineItemBase
@@ -1354,7 +1441,7 @@ class OrderLineItemPromo < OrderLineItemBase
 end
 
 # {http://api.channeladvisor.com/datacontracts/orders}OrderLineItemItemPromo
-#   lineItemType - ChannelAdvisor::OrderServiceSOAP::LineItemTypeCode
+#   lineItemType - SOAP::SOAPString
 #   unitPrice - SOAP::SOAPDecimal
 #   promoCode - SOAP::SOAPString
 #   shippingPrice - SOAP::SOAPDecimal
@@ -1373,7 +1460,7 @@ class OrderLineItemItemPromo < OrderLineItemPromo
 end
 
 # {http://api.channeladvisor.com/datacontracts/orders}OrderLineItemInvoice
-#   lineItemType - ChannelAdvisor::OrderServiceSOAP::LineItemTypeCode
+#   lineItemType - SOAP::SOAPString
 #   unitPrice - SOAP::SOAPDecimal
 class OrderLineItemInvoice < OrderLineItemBase
   attr_accessor :lineItemType
@@ -1437,105 +1524,369 @@ class CustomValue
   end
 end
 
-# {http://api.channeladvisor.com/datacontracts/orders}Order
+# {http://api.channeladvisor.com/datacontracts/orders}ArrayOfShipment
+class ArrayOfShipment < ::Array
+end
+
+# {http://api.channeladvisor.com/datacontracts/orders}Shipment
+#   shippingCarrier - SOAP::SOAPString
+#   shippingClass - SOAP::SOAPString
+#   trackingNumber - SOAP::SOAPString
+class Shipment
+  attr_accessor :shippingCarrier
+  attr_accessor :shippingClass
+  attr_accessor :trackingNumber
+
+  def initialize(shippingCarrier = nil, shippingClass = nil, trackingNumber = nil)
+    @shippingCarrier = shippingCarrier
+    @shippingClass = shippingClass
+    @trackingNumber = trackingNumber
+  end
+end
+
+# {http://api.channeladvisor.com/datacontracts/orders}OrderCriteria
+#   orderCreationFilterBeginTimeGMT - SOAP::SOAPDateTime
+#   orderCreationFilterEndTimeGMT - SOAP::SOAPDateTime
+#   statusUpdateFilterBeginTimeGMT - SOAP::SOAPDateTime
+#   statusUpdateFilterEndTimeGMT - SOAP::SOAPDateTime
+#   joinDateFiltersWithOr - SOAP::SOAPBoolean
+#   detailLevel - SOAP::SOAPString
+#   exportState - SOAP::SOAPString
+#   orderIDList - ChannelAdvisor::OrderServiceSOAP::ArrayOfInt_
+#   clientOrderIdentifierList - ChannelAdvisor::OrderServiceSOAP::ArrayOfString_
+#   orderStateFilter - SOAP::SOAPString
+#   paymentStatusFilter - SOAP::SOAPString
+#   checkoutStatusFilter - SOAP::SOAPString
+#   shippingStatusFilter - SOAP::SOAPString
+#   refundStatusFilter - SOAP::SOAPString
+#   distributionCenterCode - SOAP::SOAPString
+#   fulfillmentTypeFilter - SOAP::SOAPString
+#   pageNumberFilter - SOAP::SOAPInt
+#   pageSize - SOAP::SOAPInt
+class OrderCriteria
+  attr_accessor :orderCreationFilterBeginTimeGMT
+  attr_accessor :orderCreationFilterEndTimeGMT
+  attr_accessor :statusUpdateFilterBeginTimeGMT
+  attr_accessor :statusUpdateFilterEndTimeGMT
+  attr_accessor :joinDateFiltersWithOr
+  attr_accessor :detailLevel
+  attr_accessor :exportState
+  attr_accessor :orderIDList
+  attr_accessor :clientOrderIdentifierList
+  attr_accessor :orderStateFilter
+  attr_accessor :paymentStatusFilter
+  attr_accessor :checkoutStatusFilter
+  attr_accessor :shippingStatusFilter
+  attr_accessor :refundStatusFilter
+  attr_accessor :distributionCenterCode
+  attr_accessor :fulfillmentTypeFilter
+  attr_accessor :pageNumberFilter
+  attr_accessor :pageSize
+
+  def initialize(orderCreationFilterBeginTimeGMT = nil, orderCreationFilterEndTimeGMT = nil, statusUpdateFilterBeginTimeGMT = nil, statusUpdateFilterEndTimeGMT = nil, joinDateFiltersWithOr = nil, detailLevel = nil, exportState = nil, orderIDList = nil, clientOrderIdentifierList = nil, orderStateFilter = nil, paymentStatusFilter = nil, checkoutStatusFilter = nil, shippingStatusFilter = nil, refundStatusFilter = nil, distributionCenterCode = nil, fulfillmentTypeFilter = nil, pageNumberFilter = nil, pageSize = nil)
+    @orderCreationFilterBeginTimeGMT = orderCreationFilterBeginTimeGMT
+    @orderCreationFilterEndTimeGMT = orderCreationFilterEndTimeGMT
+    @statusUpdateFilterBeginTimeGMT = statusUpdateFilterBeginTimeGMT
+    @statusUpdateFilterEndTimeGMT = statusUpdateFilterEndTimeGMT
+    @joinDateFiltersWithOr = joinDateFiltersWithOr
+    @detailLevel = detailLevel
+    @exportState = exportState
+    @orderIDList = orderIDList
+    @clientOrderIdentifierList = clientOrderIdentifierList
+    @orderStateFilter = orderStateFilter
+    @paymentStatusFilter = paymentStatusFilter
+    @checkoutStatusFilter = checkoutStatusFilter
+    @shippingStatusFilter = shippingStatusFilter
+    @refundStatusFilter = refundStatusFilter
+    @distributionCenterCode = distributionCenterCode
+    @fulfillmentTypeFilter = fulfillmentTypeFilter
+    @pageNumberFilter = pageNumberFilter
+    @pageSize = pageSize
+  end
+end
+
+# {http://api.channeladvisor.com/datacontracts/orders}ArrayOfInt
+class ArrayOfInt_ < ::Array
+end
+
+# {http://api.channeladvisor.com/datacontracts/orders}ArrayOfString
+class ArrayOfString_ < ::Array
+end
+
+# {http://api.channeladvisor.com/datacontracts/orders}OrderResponseItem
 # abstract
+#   numberOfMatches - SOAP::SOAPInt
 #   orderTimeGMT - SOAP::SOAPDateTime
-#   clientOrderIdentifier - SOAP::SOAPString
-#   orderStatus - ChannelAdvisor::OrderServiceSOAP::OrderStatus
-#   buyerEmailAddress - SOAP::SOAPString
-#   emailOptIn - SOAP::SOAPBoolean
-#   resellerID - SOAP::SOAPString
-#   billingInfo - ChannelAdvisor::OrderServiceSOAP::BillingInfo
-#   paymentInfo - ChannelAdvisor::OrderServiceSOAP::PaymentInfo
-#   shoppingCart - ChannelAdvisor::OrderServiceSOAP::OrderCart
-#   customValueList - ChannelAdvisor::OrderServiceSOAP::ArrayOfCustomValue
-class Order
-  attr_accessor :orderTimeGMT
-  attr_accessor :clientOrderIdentifier
-  attr_accessor :orderStatus
-  attr_accessor :buyerEmailAddress
-  attr_accessor :emailOptIn
-  attr_accessor :resellerID
-  attr_accessor :billingInfo
-  attr_accessor :paymentInfo
-  attr_accessor :shoppingCart
-  attr_accessor :customValueList
-
-  def initialize(orderTimeGMT = nil, clientOrderIdentifier = nil, orderStatus = nil, buyerEmailAddress = nil, emailOptIn = nil, resellerID = nil, billingInfo = nil, paymentInfo = nil, shoppingCart = nil, customValueList = nil)
-    @orderTimeGMT = orderTimeGMT
-    @clientOrderIdentifier = clientOrderIdentifier
-    @orderStatus = orderStatus
-    @buyerEmailAddress = buyerEmailAddress
-    @emailOptIn = emailOptIn
-    @resellerID = resellerID
-    @billingInfo = billingInfo
-    @paymentInfo = paymentInfo
-    @shoppingCart = shoppingCart
-    @customValueList = customValueList
-  end
-end
-
-# {http://api.channeladvisor.com/datacontracts/orders}OrderSubmit
-#   orderTimeGMT - SOAP::SOAPDateTime
-#   clientOrderIdentifier - SOAP::SOAPString
-#   orderStatus - ChannelAdvisor::OrderServiceSOAP::OrderStatus
-#   buyerEmailAddress - SOAP::SOAPString
-#   emailOptIn - SOAP::SOAPBoolean
-#   resellerID - SOAP::SOAPString
-#   billingInfo - ChannelAdvisor::OrderServiceSOAP::BillingInfo
-#   paymentInfo - ChannelAdvisor::OrderServiceSOAP::PaymentInfo
-#   shoppingCart - ChannelAdvisor::OrderServiceSOAP::OrderCart
-#   customValueList - ChannelAdvisor::OrderServiceSOAP::ArrayOfCustomValue
-#   shippingInfo - ChannelAdvisor::OrderServiceSOAP::ShippingInfoSubmit
-class OrderSubmit < Order
-  attr_accessor :orderTimeGMT
-  attr_accessor :clientOrderIdentifier
-  attr_accessor :orderStatus
-  attr_accessor :buyerEmailAddress
-  attr_accessor :emailOptIn
-  attr_accessor :resellerID
-  attr_accessor :billingInfo
-  attr_accessor :paymentInfo
-  attr_accessor :shoppingCart
-  attr_accessor :customValueList
-  attr_accessor :shippingInfo
-
-  def initialize(orderTimeGMT = nil, clientOrderIdentifier = nil, orderStatus = nil, buyerEmailAddress = nil, emailOptIn = nil, resellerID = nil, billingInfo = nil, paymentInfo = nil, shoppingCart = nil, customValueList = nil, shippingInfo = nil)
-    @orderTimeGMT = orderTimeGMT
-    @clientOrderIdentifier = clientOrderIdentifier
-    @orderStatus = orderStatus
-    @buyerEmailAddress = buyerEmailAddress
-    @emailOptIn = emailOptIn
-    @resellerID = resellerID
-    @billingInfo = billingInfo
-    @paymentInfo = paymentInfo
-    @shoppingCart = shoppingCart
-    @customValueList = customValueList
-    @shippingInfo = shippingInfo
-  end
-end
-
-# {http://api.channeladvisor.com/datacontracts/orders}OrderRefundHistoryResponse
+#   lastUpdateDate - SOAP::SOAPDateTime
+#   totalOrderAmount - SOAP::SOAPDecimal
+#   orderState - SOAP::SOAPString
+#   dateCancelledGMT - SOAP::SOAPDateTime
 #   orderID - SOAP::SOAPInt
 #   clientOrderIdentifier - SOAP::SOAPString
-#   refundStatus - ChannelAdvisor::OrderServiceSOAP::OrderRefundStatusCode
-#   lineItemRefunds - ChannelAdvisor::OrderServiceSOAP::ArrayOfOrderLineItemRefundHistoryResponse
-class OrderRefundHistoryResponse
+#   sellerOrderID - SOAP::SOAPString
+#   flagStyle - SOAP::SOAPString
+class OrderResponseItem
+  attr_accessor :numberOfMatches
+  attr_accessor :orderTimeGMT
+  attr_accessor :lastUpdateDate
+  attr_accessor :totalOrderAmount
+  attr_accessor :orderState
+  attr_accessor :dateCancelledGMT
   attr_accessor :orderID
   attr_accessor :clientOrderIdentifier
-  attr_accessor :refundStatus
-  attr_accessor :lineItemRefunds
+  attr_accessor :sellerOrderID
+  attr_accessor :flagStyle
 
-  def initialize(orderID = nil, clientOrderIdentifier = nil, refundStatus = nil, lineItemRefunds = nil)
+  def initialize(numberOfMatches = nil, orderTimeGMT = nil, lastUpdateDate = nil, totalOrderAmount = nil, orderState = nil, dateCancelledGMT = nil, orderID = nil, clientOrderIdentifier = nil, sellerOrderID = nil, flagStyle = nil)
+    @numberOfMatches = numberOfMatches
+    @orderTimeGMT = orderTimeGMT
+    @lastUpdateDate = lastUpdateDate
+    @totalOrderAmount = totalOrderAmount
+    @orderState = orderState
+    @dateCancelledGMT = dateCancelledGMT
     @orderID = orderID
     @clientOrderIdentifier = clientOrderIdentifier
-    @refundStatus = refundStatus
-    @lineItemRefunds = lineItemRefunds
+    @sellerOrderID = sellerOrderID
+    @flagStyle = flagStyle
   end
 end
 
-# {http://api.channeladvisor.com/datacontracts/orders}ArrayOfOrderLineItemRefundHistoryResponse
-class ArrayOfOrderLineItemRefundHistoryResponse < ::Array
+# {http://api.channeladvisor.com/datacontracts/orders}OrderResponseDetailLow
+#   numberOfMatches - SOAP::SOAPInt
+#   orderTimeGMT - SOAP::SOAPDateTime
+#   lastUpdateDate - SOAP::SOAPDateTime
+#   totalOrderAmount - SOAP::SOAPDecimal
+#   orderState - SOAP::SOAPString
+#   dateCancelledGMT - SOAP::SOAPDateTime
+#   orderID - SOAP::SOAPInt
+#   clientOrderIdentifier - SOAP::SOAPString
+#   sellerOrderID - SOAP::SOAPString
+#   flagStyle - SOAP::SOAPString
+#   orderStatus - ChannelAdvisor::OrderServiceSOAP::OrderStatus
+class OrderResponseDetailLow < OrderResponseItem
+  attr_accessor :numberOfMatches
+  attr_accessor :orderTimeGMT
+  attr_accessor :lastUpdateDate
+  attr_accessor :totalOrderAmount
+  attr_accessor :orderState
+  attr_accessor :dateCancelledGMT
+  attr_accessor :orderID
+  attr_accessor :clientOrderIdentifier
+  attr_accessor :sellerOrderID
+  attr_accessor :flagStyle
+  attr_accessor :orderStatus
+
+  def initialize(numberOfMatches = nil, orderTimeGMT = nil, lastUpdateDate = nil, totalOrderAmount = nil, orderState = nil, dateCancelledGMT = nil, orderID = nil, clientOrderIdentifier = nil, sellerOrderID = nil, flagStyle = nil, orderStatus = nil)
+    @numberOfMatches = numberOfMatches
+    @orderTimeGMT = orderTimeGMT
+    @lastUpdateDate = lastUpdateDate
+    @totalOrderAmount = totalOrderAmount
+    @orderState = orderState
+    @dateCancelledGMT = dateCancelledGMT
+    @orderID = orderID
+    @clientOrderIdentifier = clientOrderIdentifier
+    @sellerOrderID = sellerOrderID
+    @flagStyle = flagStyle
+    @orderStatus = orderStatus
+  end
+end
+
+# {http://api.channeladvisor.com/datacontracts/orders}OrderResponseDetailMedium
+#   numberOfMatches - SOAP::SOAPInt
+#   orderTimeGMT - SOAP::SOAPDateTime
+#   lastUpdateDate - SOAP::SOAPDateTime
+#   totalOrderAmount - SOAP::SOAPDecimal
+#   orderState - SOAP::SOAPString
+#   dateCancelledGMT - SOAP::SOAPDateTime
+#   orderID - SOAP::SOAPInt
+#   clientOrderIdentifier - SOAP::SOAPString
+#   sellerOrderID - SOAP::SOAPString
+#   flagStyle - SOAP::SOAPString
+#   orderStatus - ChannelAdvisor::OrderServiceSOAP::OrderStatus
+#   resellerID - SOAP::SOAPString
+#   buyerEmailAddress - SOAP::SOAPString
+#   emailOptIn - SOAP::SOAPBoolean
+#   paymentInfo - ChannelAdvisor::OrderServiceSOAP::PaymentInfoResponse
+#   shippingInfo - ChannelAdvisor::OrderServiceSOAP::ShippingInfoResponse
+#   billingInfo - ChannelAdvisor::OrderServiceSOAP::BillingInfo
+#   flagDescription - SOAP::SOAPString
+class OrderResponseDetailMedium < OrderResponseDetailLow
+  attr_accessor :numberOfMatches
+  attr_accessor :orderTimeGMT
+  attr_accessor :lastUpdateDate
+  attr_accessor :totalOrderAmount
+  attr_accessor :orderState
+  attr_accessor :dateCancelledGMT
+  attr_accessor :orderID
+  attr_accessor :clientOrderIdentifier
+  attr_accessor :sellerOrderID
+  attr_accessor :flagStyle
+  attr_accessor :orderStatus
+  attr_accessor :resellerID
+  attr_accessor :buyerEmailAddress
+  attr_accessor :emailOptIn
+  attr_accessor :paymentInfo
+  attr_accessor :shippingInfo
+  attr_accessor :billingInfo
+  attr_accessor :flagDescription
+
+  def initialize(numberOfMatches = nil, orderTimeGMT = nil, lastUpdateDate = nil, totalOrderAmount = nil, orderState = nil, dateCancelledGMT = nil, orderID = nil, clientOrderIdentifier = nil, sellerOrderID = nil, flagStyle = nil, orderStatus = nil, resellerID = nil, buyerEmailAddress = nil, emailOptIn = nil, paymentInfo = nil, shippingInfo = nil, billingInfo = nil, flagDescription = nil)
+    @numberOfMatches = numberOfMatches
+    @orderTimeGMT = orderTimeGMT
+    @lastUpdateDate = lastUpdateDate
+    @totalOrderAmount = totalOrderAmount
+    @orderState = orderState
+    @dateCancelledGMT = dateCancelledGMT
+    @orderID = orderID
+    @clientOrderIdentifier = clientOrderIdentifier
+    @sellerOrderID = sellerOrderID
+    @flagStyle = flagStyle
+    @orderStatus = orderStatus
+    @resellerID = resellerID
+    @buyerEmailAddress = buyerEmailAddress
+    @emailOptIn = emailOptIn
+    @paymentInfo = paymentInfo
+    @shippingInfo = shippingInfo
+    @billingInfo = billingInfo
+    @flagDescription = flagDescription
+  end
+end
+
+# {http://api.channeladvisor.com/datacontracts/orders}OrderResponseDetailHigh
+#   numberOfMatches - SOAP::SOAPInt
+#   orderTimeGMT - SOAP::SOAPDateTime
+#   lastUpdateDate - SOAP::SOAPDateTime
+#   totalOrderAmount - SOAP::SOAPDecimal
+#   orderState - SOAP::SOAPString
+#   dateCancelledGMT - SOAP::SOAPDateTime
+#   orderID - SOAP::SOAPInt
+#   clientOrderIdentifier - SOAP::SOAPString
+#   sellerOrderID - SOAP::SOAPString
+#   flagStyle - SOAP::SOAPString
+#   orderStatus - ChannelAdvisor::OrderServiceSOAP::OrderStatus
+#   resellerID - SOAP::SOAPString
+#   buyerEmailAddress - SOAP::SOAPString
+#   emailOptIn - SOAP::SOAPBoolean
+#   paymentInfo - ChannelAdvisor::OrderServiceSOAP::PaymentInfoResponse
+#   shippingInfo - ChannelAdvisor::OrderServiceSOAP::ShippingInfoResponse
+#   billingInfo - ChannelAdvisor::OrderServiceSOAP::BillingInfo
+#   flagDescription - SOAP::SOAPString
+#   shoppingCart - ChannelAdvisor::OrderServiceSOAP::OrderCart
+class OrderResponseDetailHigh < OrderResponseDetailMedium
+  attr_accessor :numberOfMatches
+  attr_accessor :orderTimeGMT
+  attr_accessor :lastUpdateDate
+  attr_accessor :totalOrderAmount
+  attr_accessor :orderState
+  attr_accessor :dateCancelledGMT
+  attr_accessor :orderID
+  attr_accessor :clientOrderIdentifier
+  attr_accessor :sellerOrderID
+  attr_accessor :flagStyle
+  attr_accessor :orderStatus
+  attr_accessor :resellerID
+  attr_accessor :buyerEmailAddress
+  attr_accessor :emailOptIn
+  attr_accessor :paymentInfo
+  attr_accessor :shippingInfo
+  attr_accessor :billingInfo
+  attr_accessor :flagDescription
+  attr_accessor :shoppingCart
+
+  def initialize(numberOfMatches = nil, orderTimeGMT = nil, lastUpdateDate = nil, totalOrderAmount = nil, orderState = nil, dateCancelledGMT = nil, orderID = nil, clientOrderIdentifier = nil, sellerOrderID = nil, flagStyle = nil, orderStatus = nil, resellerID = nil, buyerEmailAddress = nil, emailOptIn = nil, paymentInfo = nil, shippingInfo = nil, billingInfo = nil, flagDescription = nil, shoppingCart = nil)
+    @numberOfMatches = numberOfMatches
+    @orderTimeGMT = orderTimeGMT
+    @lastUpdateDate = lastUpdateDate
+    @totalOrderAmount = totalOrderAmount
+    @orderState = orderState
+    @dateCancelledGMT = dateCancelledGMT
+    @orderID = orderID
+    @clientOrderIdentifier = clientOrderIdentifier
+    @sellerOrderID = sellerOrderID
+    @flagStyle = flagStyle
+    @orderStatus = orderStatus
+    @resellerID = resellerID
+    @buyerEmailAddress = buyerEmailAddress
+    @emailOptIn = emailOptIn
+    @paymentInfo = paymentInfo
+    @shippingInfo = shippingInfo
+    @billingInfo = billingInfo
+    @flagDescription = flagDescription
+    @shoppingCart = shoppingCart
+  end
+end
+
+# {http://api.channeladvisor.com/datacontracts/orders}OrderResponseDetailComplete
+#   numberOfMatches - SOAP::SOAPInt
+#   orderTimeGMT - SOAP::SOAPDateTime
+#   lastUpdateDate - SOAP::SOAPDateTime
+#   totalOrderAmount - SOAP::SOAPDecimal
+#   orderState - SOAP::SOAPString
+#   dateCancelledGMT - SOAP::SOAPDateTime
+#   orderID - SOAP::SOAPInt
+#   clientOrderIdentifier - SOAP::SOAPString
+#   sellerOrderID - SOAP::SOAPString
+#   flagStyle - SOAP::SOAPString
+#   orderStatus - ChannelAdvisor::OrderServiceSOAP::OrderStatus
+#   resellerID - SOAP::SOAPString
+#   buyerEmailAddress - SOAP::SOAPString
+#   emailOptIn - SOAP::SOAPBoolean
+#   paymentInfo - ChannelAdvisor::OrderServiceSOAP::PaymentInfoResponse
+#   shippingInfo - ChannelAdvisor::OrderServiceSOAP::ShippingInfoResponse
+#   billingInfo - ChannelAdvisor::OrderServiceSOAP::BillingInfo
+#   flagDescription - SOAP::SOAPString
+#   shoppingCart - ChannelAdvisor::OrderServiceSOAP::OrderCart
+#   customValueList - ChannelAdvisor::OrderServiceSOAP::ArrayOfCustomValue
+#   buyerIpAddress - SOAP::SOAPString
+#   transactionNotes - SOAP::SOAPString
+class OrderResponseDetailComplete < OrderResponseDetailHigh
+  attr_accessor :numberOfMatches
+  attr_accessor :orderTimeGMT
+  attr_accessor :lastUpdateDate
+  attr_accessor :totalOrderAmount
+  attr_accessor :orderState
+  attr_accessor :dateCancelledGMT
+  attr_accessor :orderID
+  attr_accessor :clientOrderIdentifier
+  attr_accessor :sellerOrderID
+  attr_accessor :flagStyle
+  attr_accessor :orderStatus
+  attr_accessor :resellerID
+  attr_accessor :buyerEmailAddress
+  attr_accessor :emailOptIn
+  attr_accessor :paymentInfo
+  attr_accessor :shippingInfo
+  attr_accessor :billingInfo
+  attr_accessor :flagDescription
+  attr_accessor :shoppingCart
+  attr_accessor :customValueList
+  attr_accessor :buyerIpAddress
+  attr_accessor :transactionNotes
+
+  def initialize(numberOfMatches = nil, orderTimeGMT = nil, lastUpdateDate = nil, totalOrderAmount = nil, orderState = nil, dateCancelledGMT = nil, orderID = nil, clientOrderIdentifier = nil, sellerOrderID = nil, flagStyle = nil, orderStatus = nil, resellerID = nil, buyerEmailAddress = nil, emailOptIn = nil, paymentInfo = nil, shippingInfo = nil, billingInfo = nil, flagDescription = nil, shoppingCart = nil, customValueList = nil, buyerIpAddress = nil, transactionNotes = nil)
+    @numberOfMatches = numberOfMatches
+    @orderTimeGMT = orderTimeGMT
+    @lastUpdateDate = lastUpdateDate
+    @totalOrderAmount = totalOrderAmount
+    @orderState = orderState
+    @dateCancelledGMT = dateCancelledGMT
+    @orderID = orderID
+    @clientOrderIdentifier = clientOrderIdentifier
+    @sellerOrderID = sellerOrderID
+    @flagStyle = flagStyle
+    @orderStatus = orderStatus
+    @resellerID = resellerID
+    @buyerEmailAddress = buyerEmailAddress
+    @emailOptIn = emailOptIn
+    @paymentInfo = paymentInfo
+    @shippingInfo = shippingInfo
+    @billingInfo = billingInfo
+    @flagDescription = flagDescription
+    @shoppingCart = shoppingCart
+    @customValueList = customValueList
+    @buyerIpAddress = buyerIpAddress
+    @transactionNotes = transactionNotes
+  end
 end
 
 # {http://api.channeladvisor.com/webservices/}ResultStatus
@@ -1544,200 +1895,27 @@ class ResultStatus < ::String
   Success = new("Success")
 end
 
-# {http://api.channeladvisor.com/datacontracts/orders}RefundAdjustmentReason
-class RefundAdjustmentReason < ::String
-  AlternateItemProvided = new("AlternateItemProvided")
-  BuyerCancelled = new("BuyerCancelled")
-  CouldNotShip = new("CouldNotShip")
-  CustomerExchange = new("CustomerExchange")
-  CustomerReturnedItem = new("CustomerReturnedItem")
-  GeneralAdjustment = new("GeneralAdjustment")
-  ItemNotAvailable = new("ItemNotAvailable")
-  MerchandiseNotReceived = new("MerchandiseNotReceived")
-  ShippingAddressUndeliverable = new("ShippingAddressUndeliverable")
-end
-
-# {http://api.channeladvisor.com/datacontracts/orders}SiteToken
-class SiteToken < ::String
-  AMAZON_AUCTIONS = new("AMAZON_AUCTIONS")
-  AMAZON_DE = new("AMAZON_DE")
-  AMAZON_FR = new("AMAZON_FR")
-  AMAZON_MARKETPLACE = new("AMAZON_MARKETPLACE")
-  AMAZON_MERCHANTSAT = new("AMAZON_MERCHANTSAT")
-  AMAZON_UK = new("AMAZON_UK")
-  AMAZON_US = new("AMAZON_US")
-  BUY_DOT_COM = new("BUY_DOT_COM")
-  CHANNELADVISOR_STORE = new("CHANNELADVISOR_STORE")
-  DEMANDWARE_STORE = new("DEMANDWARE_STORE")
-  DIRECT_SALE = new("DIRECT_SALE")
-  EBAY_AU = new("EBAY_AU")
-  EBAY_CA = new("EBAY_CA")
-  EBAY_DE = new("EBAY_DE")
-  EBAY_ES = new("EBAY_ES")
-  EBAY_FR = new("EBAY_FR")
-  EBAY_IE = new("EBAY_IE")
-  EBAY_IT = new("EBAY_IT")
-  EBAY_MOTORS = new("EBAY_MOTORS")
-  EBAY_MOTORS_FIXED_PRICE = new("EBAY_MOTORS_FIXED_PRICE")
-  EBAY_STORES = new("EBAY_STORES")
-  EBAY_UK = new("EBAY_UK")
-  EBAY_US = new("EBAY_US")
-  OVERSTOCK = new("OVERSTOCK")
-  OVERSTOCK_SHOPPING = new("OVERSTOCK_SHOPPING")
-  PIXMANIA = new("PIXMANIA")
-  STOREADVISOR_PREMIUM = new("STOREADVISOR_PREMIUM")
-  TRADING_POST = new("TRADING_POST")
-  UNKNOWN = new("UNKNOWN")
-  YAHOO = new("YAHOO")
-  YAHOO_STORES = new("YAHOO_STORES")
-end
-
-# {http://api.channeladvisor.com/datacontracts/orders}AsyncStatusCode
-class AsyncStatusCode < ::String
-  AcknowledgedPostProcessingNotComplete = new("AcknowledgedPostProcessingNotComplete")
-  Error = new("Error")
-  NoChange = new("NoChange")
-  PostProcessingComplete = new("PostProcessingComplete")
-  ProcessedNotAcknowledged = new("ProcessedNotAcknowledged")
-  SubmittedNotProcessed = new("SubmittedNotProcessed")
-end
-
-# {http://api.channeladvisor.com/datacontracts/orders}DetailLevelType
-class DetailLevelType < ::String
-  Complete = new("Complete")
-  High = new("High")
-  Low = new("Low")
-  Medium = new("Medium")
-end
-
-# {http://api.channeladvisor.com/datacontracts/orders}ExportStateType
-class ExportStateType < ::String
-  Exported = new("Exported")
-  NotExported = new("NotExported")
-  Unknown = new("Unknown")
-end
-
-# {http://api.channeladvisor.com/datacontracts/orders}OrderStateCode
-class OrderStateCode < ::String
-  Active = new("Active")
-  Archived = new("Archived")
-  Cancelled = new("Cancelled")
-end
-
-# {http://api.channeladvisor.com/datacontracts/orders}PaymentStatusCode
-class PaymentStatusCode < ::String
-  Cleared = new("Cleared")
-  Deposited = new("Deposited")
-  Failed = new("Failed")
-  NoChange = new("NoChange")
-  NotSubmitted = new("NotSubmitted")
-  Submitted = new("Submitted")
-end
-
-# {http://api.channeladvisor.com/datacontracts/orders}CheckoutStatusCode
-class CheckoutStatusCode < ::String
-  Cancelled = new("Cancelled")
-  Completed = new("Completed")
-  CompletedOffline = new("CompletedOffline")
-  NoChange = new("NoChange")
-  NotVisited = new("NotVisited")
-  OnHold = new("OnHold")
-  Visited = new("Visited")
-end
-
-# {http://api.channeladvisor.com/datacontracts/orders}ShippingStatusCode
-class ShippingStatusCode < ::String
-  NoChange = new("NoChange")
-  PartiallyShipped = new("PartiallyShipped")
-  Shipped = new("Shipped")
-  Unshipped = new("Unshipped")
-end
-
-# {http://api.channeladvisor.com/datacontracts/orders}FlagType
-class FlagType < ::String
-  BlueFlag = new("BlueFlag")
-  ExclamationPoint = new("ExclamationPoint")
-  GreenFlag = new("GreenFlag")
-  ItemCopied = new("ItemCopied")
-  NoFlag = new("NoFlag")
-  NotAvailable = new("NotAvailable")
-  Price = new("Price")
-  QuestionMark = new("QuestionMark")
-  RedFlag = new("RedFlag")
-  YellowFlag = new("YellowFlag")
-end
-
-# {http://api.channeladvisor.com/datacontracts/orders}OrderRefundStatusCode
-class OrderRefundStatusCode < ::String
-  FailedAttemptsOnly = new("FailedAttemptsOnly")
-  LineItemLevel = new("LineItemLevel")
-  NoRefunds = new("NoRefunds")
-  OrderAndLineItemLevel = new("OrderAndLineItemLevel")
-  OrderLevel = new("OrderLevel")
-end
-
-# {http://api.channeladvisor.com/datacontracts/orders}CheckoutSourceType
-class CheckoutSourceType < ::String
-  CA_Checkout = new("CA_Checkout")
-  Demandware_Checkout = new("Demandware_Checkout")
-  Google_Checkout = new("Google_Checkout")
-  Overstock_Shopping = new("Overstock_Shopping")
-  PayPal = new("PayPal")
-  Site_Checkout = new("Site_Checkout")
-  Unspecified = new("Unspecified")
-  YahooStores_Checkout = new("YahooStores_Checkout")
-end
-
-# {http://api.channeladvisor.com/datacontracts/orders}VAT_Calculation_Type
-class VAT_Calculation_Type < ::String
-  Unspecified = new("Unspecified")
-  VAT_EXCLUSIVE = new("VAT_EXCLUSIVE")
-  VAT_INCLUSIVE = new("VAT_INCLUSIVE")
-end
-
-# {http://api.channeladvisor.com/datacontracts/orders}LineItemTypeCode
-class LineItemTypeCode < ::String
-  AdditionalCostOrDiscount = new("AdditionalCostOrDiscount")
-  BuyerOptInIncentive = new("BuyerOptInIncentive")
-  GiftWrap = new("GiftWrap")
-  Listing = new("Listing")
-  Promotion = new("Promotion")
-  SKU = new("SKU")
-  SalesTax = new("SalesTax")
-  Shipping = new("Shipping")
-  ShippingInsurance = new("ShippingInsurance")
-  VATGiftWrap = new("VATGiftWrap")
-  VATShipping = new("VATShipping")
-end
-
-# {http://api.channeladvisor.com/datacontracts/orders}CheckoutPaymentStatusCode
-class CheckoutPaymentStatusCode < ::String
-  CheckoutCanceledPaymentFailed = new("CheckoutCanceledPaymentFailed")
-  CheckoutReopenedPaymentFailed = new("CheckoutReopenedPaymentFailed")
-  CheckoutSamePaymentCleared = new("CheckoutSamePaymentCleared")
-  CheckoutSamePaymentDeposited = new("CheckoutSamePaymentDeposited")
-  CheckoutSamePaymentSubmitted = new("CheckoutSamePaymentSubmitted")
-  NoChange = new("NoChange")
-end
-
 # {http://api.channeladvisor.com/webservices/}SetOrdersExportStatus
 #   accountID - SOAP::SOAPString
-#   clientOrderIdentifiers - ChannelAdvisor::OrderServiceSOAP::ArrayOfString
+#   orderIDList - ChannelAdvisor::OrderServiceSOAP::ArrayOfInt
+#   clientOrderIdentifierList - ChannelAdvisor::OrderServiceSOAP::ArrayOfString
 #   markAsExported - SOAP::SOAPBoolean
 class SetOrdersExportStatus
   attr_accessor :accountID
-  attr_accessor :clientOrderIdentifiers
+  attr_accessor :orderIDList
+  attr_accessor :clientOrderIdentifierList
   attr_accessor :markAsExported
 
-  def initialize(accountID = nil, clientOrderIdentifiers = nil, markAsExported = nil)
+  def initialize(accountID = nil, orderIDList = nil, clientOrderIdentifierList = nil, markAsExported = nil)
     @accountID = accountID
-    @clientOrderIdentifiers = clientOrderIdentifiers
+    @orderIDList = orderIDList
+    @clientOrderIdentifierList = clientOrderIdentifierList
     @markAsExported = markAsExported
   end
 end
 
 # {http://api.channeladvisor.com/webservices/}SetOrdersExportStatusResponse
-#   setOrdersExportStatusResult - ChannelAdvisor::OrderServiceSOAP::APIResultOfArrayOfBoolean
+#   setOrdersExportStatusResult - ChannelAdvisor::OrderServiceSOAP::APIResultOfArrayOfSetExportStatusResponse
 class SetOrdersExportStatusResponse
   attr_accessor :setOrdersExportStatusResult
 
@@ -1766,52 +1944,6 @@ class SubmitOrderRefundResponse
 
   def initialize(submitOrderRefundResult = nil)
     @submitOrderRefundResult = submitOrderRefundResult
-  end
-end
-
-# {http://api.channeladvisor.com/webservices/}GetOrderList
-#   accountID - SOAP::SOAPString
-#   orderCriteria - ChannelAdvisor::OrderServiceSOAP::OrderCriteria
-class GetOrderList
-  attr_accessor :accountID
-  attr_accessor :orderCriteria
-
-  def initialize(accountID = nil, orderCriteria = nil)
-    @accountID = accountID
-    @orderCriteria = orderCriteria
-  end
-end
-
-# {http://api.channeladvisor.com/webservices/}GetOrderListResponse
-#   getOrderListResult - ChannelAdvisor::OrderServiceSOAP::APIResultOfArrayOfOrderResponseItem
-class GetOrderListResponse
-  attr_accessor :getOrderListResult
-
-  def initialize(getOrderListResult = nil)
-    @getOrderListResult = getOrderListResult
-  end
-end
-
-# {http://api.channeladvisor.com/webservices/}SubmitOrder
-#   accountID - SOAP::SOAPString
-#   order - ChannelAdvisor::OrderServiceSOAP::OrderSubmit
-class SubmitOrder
-  attr_accessor :accountID
-  attr_accessor :order
-
-  def initialize(accountID = nil, order = nil)
-    @accountID = accountID
-    @order = order
-  end
-end
-
-# {http://api.channeladvisor.com/webservices/}SubmitOrderResponse
-#   submitOrderResult - ChannelAdvisor::OrderServiceSOAP::APIResultOfInt32
-class SubmitOrderResponse
-  attr_accessor :submitOrderResult
-
-  def initialize(submitOrderResult = nil)
-    @submitOrderResult = submitOrderResult
   end
 end
 
@@ -1913,6 +2045,104 @@ class UpdateOrderListResponse
 
   def initialize(updateOrderListResult = nil)
     @updateOrderListResult = updateOrderListResult
+  end
+end
+
+# {http://api.channeladvisor.com/webservices/}OrderMerge
+#   accountID - SOAP::SOAPString
+#   primaryOrderID - SOAP::SOAPInt
+#   orderIDMergeList - ChannelAdvisor::OrderServiceSOAP::ArrayOfInt
+class OrderMerge
+  attr_accessor :accountID
+  attr_accessor :primaryOrderID
+  attr_accessor :orderIDMergeList
+
+  def initialize(accountID = nil, primaryOrderID = nil, orderIDMergeList = nil)
+    @accountID = accountID
+    @primaryOrderID = primaryOrderID
+    @orderIDMergeList = orderIDMergeList
+  end
+end
+
+# {http://api.channeladvisor.com/webservices/}OrderMergeResponse
+#   orderMergeResult - ChannelAdvisor::OrderServiceSOAP::APIResultOfBoolean
+class OrderMergeResponse
+  attr_accessor :orderMergeResult
+
+  def initialize(orderMergeResult = nil)
+    @orderMergeResult = orderMergeResult
+  end
+end
+
+# {http://api.channeladvisor.com/webservices/}OrderSplit
+#   accountID - SOAP::SOAPString
+#   orderID - SOAP::SOAPInt
+#   lineItemIDList - ChannelAdvisor::OrderServiceSOAP::ArrayOfInt
+class OrderSplit
+  attr_accessor :accountID
+  attr_accessor :orderID
+  attr_accessor :lineItemIDList
+
+  def initialize(accountID = nil, orderID = nil, lineItemIDList = nil)
+    @accountID = accountID
+    @orderID = orderID
+    @lineItemIDList = lineItemIDList
+  end
+end
+
+# {http://api.channeladvisor.com/webservices/}OrderSplitResponse
+#   orderSplitResult - ChannelAdvisor::OrderServiceSOAP::APIResultOfBoolean
+class OrderSplitResponse
+  attr_accessor :orderSplitResult
+
+  def initialize(orderSplitResult = nil)
+    @orderSplitResult = orderSplitResult
+  end
+end
+
+# {http://api.channeladvisor.com/webservices/}SubmitOrder
+#   accountID - SOAP::SOAPString
+#   order - ChannelAdvisor::OrderServiceSOAP::OrderSubmit
+class SubmitOrder
+  attr_accessor :accountID
+  attr_accessor :order
+
+  def initialize(accountID = nil, order = nil)
+    @accountID = accountID
+    @order = order
+  end
+end
+
+# {http://api.channeladvisor.com/webservices/}SubmitOrderResponse
+#   submitOrderResult - ChannelAdvisor::OrderServiceSOAP::APIResultOfInt32
+class SubmitOrderResponse
+  attr_accessor :submitOrderResult
+
+  def initialize(submitOrderResult = nil)
+    @submitOrderResult = submitOrderResult
+  end
+end
+
+# {http://api.channeladvisor.com/webservices/}GetOrderList
+#   accountID - SOAP::SOAPString
+#   orderCriteria - ChannelAdvisor::OrderServiceSOAP::OrderCriteria
+class GetOrderList
+  attr_accessor :accountID
+  attr_accessor :orderCriteria
+
+  def initialize(accountID = nil, orderCriteria = nil)
+    @accountID = accountID
+    @orderCriteria = orderCriteria
+  end
+end
+
+# {http://api.channeladvisor.com/webservices/}GetOrderListResponse
+#   getOrderListResult - ChannelAdvisor::OrderServiceSOAP::APIResultOfArrayOfOrderResponseItem
+class GetOrderListResponse
+  attr_accessor :getOrderListResult
+
+  def initialize(getOrderListResult = nil)
+    @getOrderListResult = getOrderListResult
   end
 end
 

--- a/lib/channel_advisor/shipping_service/client.rb
+++ b/lib/channel_advisor/shipping_service/client.rb
@@ -6,7 +6,7 @@ module ChannelAdvisor
 module ShippingServiceSOAP
 
 class ShippingServiceSoap < ::SOAP::RPC::Driver
-  DefaultEndpointUrl = "https://api.channeladvisor.com/ChannelAdvisorAPI/v4/ShippingService.asmx"
+  DefaultEndpointUrl = "https://api.channeladvisor.com/ChannelAdvisorAPI/v7/ShippingService.asmx"
 
   Methods = [
     [ "http://api.channeladvisor.com/webservices/GetShippingRateList",
@@ -25,10 +25,10 @@ class ShippingServiceSoap < ::SOAP::RPC::Driver
         :response_style => :document, :response_use => :literal,
         :faults => {} }
     ],
-    [ "http://api.channeladvisor.com/webservices/OrderShipped",
-      "orderShipped",
-      [ [:in, "parameters", ["::SOAP::SOAPElement", "http://api.channeladvisor.com/webservices/", "OrderShipped"]],
-        [:out, "parameters", ["::SOAP::SOAPElement", "http://api.channeladvisor.com/webservices/", "OrderShippedResponse"]] ],
+    [ "http://api.channeladvisor.com/webservices/GetOrderShipmentHistoryList",
+      "getOrderShipmentHistoryList",
+      [ [:in, "parameters", ["::SOAP::SOAPElement", "http://api.channeladvisor.com/webservices/", "GetOrderShipmentHistoryList"]],
+        [:out, "parameters", ["::SOAP::SOAPElement", "http://api.channeladvisor.com/webservices/", "GetOrderShipmentHistoryListResponse"]] ],
       { :request_style =>  :document, :request_use =>  :literal,
         :response_style => :document, :response_use => :literal,
         :faults => {} }

--- a/lib/channel_advisor/shipping_service/mapping_registry.rb
+++ b/lib/channel_advisor/shipping_service/mapping_registry.rb
@@ -90,30 +90,38 @@ module DefaultMappingRegistry
   )
 
   EncodedRegistry.register(
-    :class => ChannelAdvisor::ShippingServiceSOAP::APIResultOfBoolean,
-    :schema_type => XSD::QName.new(NsWebservices, "APIResultOfBoolean"),
+    :class => ChannelAdvisor::ShippingServiceSOAP::ArrayOfInt,
+    :schema_type => XSD::QName.new(NsWebservices, "ArrayOfInt"),
+    :schema_element => [
+      ["int", "SOAP::SOAPInt[]", [0, nil]]
+    ]
+  )
+
+  EncodedRegistry.register(
+    :class => ChannelAdvisor::ShippingServiceSOAP::ArrayOfString,
+    :schema_type => XSD::QName.new(NsWebservices, "ArrayOfString"),
+    :schema_element => [
+      ["string", "SOAP::SOAPString[]", [0, nil]]
+    ]
+  )
+
+  EncodedRegistry.register(
+    :class => ChannelAdvisor::ShippingServiceSOAP::APIResultOfArrayOfOrderShipmentHistoryResponse,
+    :schema_type => XSD::QName.new(NsWebservices, "APIResultOfArrayOfOrderShipmentHistoryResponse"),
     :schema_element => [
       ["status", ["ChannelAdvisor::ShippingServiceSOAP::ResultStatus", XSD::QName.new(NsWebservices, "Status")]],
       ["messageCode", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "MessageCode")]],
       ["message", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Message")], [0, 1]],
       ["data", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Data")], [0, 1]],
-      ["resultData", ["SOAP::SOAPBoolean", XSD::QName.new(NsWebservices, "ResultData")]]
+      ["resultData", ["ChannelAdvisor::ShippingServiceSOAP::ArrayOfOrderShipmentHistoryResponse", XSD::QName.new(NsWebservices, "ResultData")], [0, 1]]
     ]
   )
 
   EncodedRegistry.register(
-    :class => ChannelAdvisor::ShippingServiceSOAP::OrderShipmentList,
-    :schema_type => XSD::QName.new(NsWebservices, "OrderShipmentList"),
+    :class => ChannelAdvisor::ShippingServiceSOAP::ArrayOfOrderShipmentHistoryResponse,
+    :schema_type => XSD::QName.new(NsWebservices, "ArrayOfOrderShipmentHistoryResponse"),
     :schema_element => [
-      ["shipmentList", ["ChannelAdvisor::ShippingServiceSOAP::ArrayOfOrderShipment", XSD::QName.new(NsWebservices, "ShipmentList")], [0, 1]]
-    ]
-  )
-
-  EncodedRegistry.register(
-    :class => ChannelAdvisor::ShippingServiceSOAP::ArrayOfOrderShipment,
-    :schema_type => XSD::QName.new(NsWebservices, "ArrayOfOrderShipment"),
-    :schema_element => [
-      ["orderShipment", ["ChannelAdvisor::ShippingServiceSOAP::OrderShipment[]", XSD::QName.new(NsWebservices, "OrderShipment")], [0, nil]]
+      ["orderShipmentHistoryResponse", ["ChannelAdvisor::ShippingServiceSOAP::OrderShipmentHistoryResponse[]", XSD::QName.new(NsWebservices, "OrderShipmentHistoryResponse")], [0, nil]]
     ]
   )
 
@@ -121,9 +129,9 @@ module DefaultMappingRegistry
     :class => ChannelAdvisor::ShippingServiceSOAP::OrderShipment,
     :schema_type => XSD::QName.new(NsWebservices, "OrderShipment"),
     :schema_element => [
-      ["orderId", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "OrderId")]],
+      ["orderID", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "OrderID")]],
       ["clientOrderIdentifier", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "ClientOrderIdentifier")], [0, 1]],
-      ["shipmentType", ["ChannelAdvisor::ShippingServiceSOAP::ShipmentTypeEnum", XSD::QName.new(NsWebservices, "ShipmentType")]],
+      ["shipmentType", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "ShipmentType")], [0, 1]],
       ["partialShipment", ["ChannelAdvisor::ShippingServiceSOAP::PartialShipmentContents", XSD::QName.new(NsWebservices, "PartialShipment")], [0, 1]],
       ["fullShipment", ["ChannelAdvisor::ShippingServiceSOAP::FullShipmentContents", XSD::QName.new(NsWebservices, "FullShipment")], [0, 1]]
     ]
@@ -133,31 +141,17 @@ module DefaultMappingRegistry
     :class => ChannelAdvisor::ShippingServiceSOAP::PartialShipmentContents,
     :schema_type => XSD::QName.new(NsWebservices, "PartialShipmentContents"),
     :schema_element => [
-      ["shipmentContents", "ChannelAdvisor::ShippingServiceSOAP::ShipmentContents"],
-      ["dateShippedGMT", "SOAP::SOAPDateTime"],
-      ["carrierCode", "SOAP::SOAPString", [0, 1]],
-      ["classCode", "SOAP::SOAPString", [0, 1]],
-      ["trackingNumber", "SOAP::SOAPString", [0, 1]],
-      ["sellerFulfillmentID", "SOAP::SOAPString", [0, 1]],
-      ["shipmentCost", "SOAP::SOAPDecimal"],
-      ["shipmentTaxCost", "SOAP::SOAPDecimal"],
-      ["insuranceCost", "SOAP::SOAPDecimal"]
-    ]
-  )
-
-  EncodedRegistry.register(
-    :class => ChannelAdvisor::ShippingServiceSOAP::ShipmentContents,
-    :schema_type => XSD::QName.new(NsWebservices, "ShipmentContents"),
-    :schema_element => [
-      ["lineItemList", ["ChannelAdvisor::ShippingServiceSOAP::ArrayOfLineItem", XSD::QName.new(NsWebservices, "LineItemList")], [0, 1]]
-    ]
-  )
-
-  EncodedRegistry.register(
-    :class => ChannelAdvisor::ShippingServiceSOAP::ArrayOfLineItem,
-    :schema_type => XSD::QName.new(NsWebservices, "ArrayOfLineItem"),
-    :schema_element => [
-      ["lineItem", ["ChannelAdvisor::ShippingServiceSOAP::LineItem[]", XSD::QName.new(NsWebservices, "LineItem")], [0, nil]]
+      ["lineItemList", ["ChannelAdvisor::ShippingServiceSOAP::LineItem[]", XSD::QName.new(NsWebservices, "LineItemList")], [0, nil]],
+      ["dateShippedGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsWebservices, "DateShippedGMT")]],
+      ["carrierCode", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "CarrierCode")], [0, 1]],
+      ["classCode", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "ClassCode")], [0, 1]],
+      ["trackingNumber", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "TrackingNumber")], [0, 1]],
+      ["sellerFulfillmentID", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "SellerFulfillmentID")], [0, 1]],
+      ["shipmentCost", ["SOAP::SOAPDecimal", XSD::QName.new(NsWebservices, "ShipmentCost")]],
+      ["shipmentTaxCost", ["SOAP::SOAPDecimal", XSD::QName.new(NsWebservices, "ShipmentTaxCost")]],
+      ["insuranceCost", ["SOAP::SOAPDecimal", XSD::QName.new(NsWebservices, "InsuranceCost")]],
+      ["fulfillmentType", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "FulfillmentType")], [0, 1]],
+      ["fulfillmentStatus", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "FulfillmentStatus")], [0, 1]]
     ]
   )
 
@@ -174,14 +168,14 @@ module DefaultMappingRegistry
     :class => ChannelAdvisor::ShippingServiceSOAP::FullShipmentContents,
     :schema_type => XSD::QName.new(NsWebservices, "FullShipmentContents"),
     :schema_element => [
-      ["dateShippedGMT", "SOAP::SOAPDateTime"],
-      ["carrierCode", "SOAP::SOAPString", [0, 1]],
-      ["classCode", "SOAP::SOAPString", [0, 1]],
-      ["trackingNumber", "SOAP::SOAPString", [0, 1]],
-      ["sellerFulfillmentID", "SOAP::SOAPString", [0, 1]],
-      ["shipmentCost", "SOAP::SOAPDecimal"],
-      ["shipmentTaxCost", "SOAP::SOAPDecimal"],
-      ["insuranceCost", "SOAP::SOAPDecimal"]
+      ["dateShippedGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsWebservices, "DateShippedGMT")]],
+      ["carrierCode", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "CarrierCode")], [0, 1]],
+      ["classCode", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "ClassCode")], [0, 1]],
+      ["trackingNumber", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "TrackingNumber")], [0, 1]],
+      ["sellerFulfillmentID", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "SellerFulfillmentID")], [0, 1]],
+      ["shipmentCost", ["SOAP::SOAPDecimal", XSD::QName.new(NsWebservices, "ShipmentCost")]],
+      ["shipmentTaxCost", ["SOAP::SOAPDecimal", XSD::QName.new(NsWebservices, "ShipmentTaxCost")]],
+      ["insuranceCost", ["SOAP::SOAPDecimal", XSD::QName.new(NsWebservices, "InsuranceCost")]]
     ]
   )
 
@@ -218,6 +212,63 @@ module DefaultMappingRegistry
   )
 
   EncodedRegistry.register(
+    :class => ChannelAdvisor::ShippingServiceSOAP::OrderShipmentHistoryResponse,
+    :schema_type => XSD::QName.new(NsShippingService, "OrderShipmentHistoryResponse"),
+    :schema_element => [
+      ["orderID", ["SOAP::SOAPInt", XSD::QName.new(NsShippingService, "OrderID")]],
+      ["clientOrderIdentifier", ["SOAP::SOAPString", XSD::QName.new(NsShippingService, "ClientOrderIdentifier")], [0, 1]],
+      ["shippingStatus", ["SOAP::SOAPString", XSD::QName.new(NsShippingService, "ShippingStatus")], [0, 1]],
+      ["shippingStatusUpdateDateGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsShippingService, "ShippingStatusUpdateDateGMT")]],
+      ["orderShipments", ["ChannelAdvisor::ShippingServiceSOAP::ArrayOfOrderShipmentResponse", XSD::QName.new(NsShippingService, "OrderShipments")], [0, 1]]
+    ]
+  )
+
+  EncodedRegistry.register(
+    :class => ChannelAdvisor::ShippingServiceSOAP::ArrayOfOrderShipmentResponse,
+    :schema_type => XSD::QName.new(NsShippingService, "ArrayOfOrderShipmentResponse"),
+    :schema_element => [
+      ["orderShipmentResponse", ["ChannelAdvisor::ShippingServiceSOAP::OrderShipmentResponse[]", XSD::QName.new(NsShippingService, "OrderShipmentResponse")], [0, nil]]
+    ]
+  )
+
+  EncodedRegistry.register(
+    :class => ChannelAdvisor::ShippingServiceSOAP::OrderShipmentResponse,
+    :schema_type => XSD::QName.new(NsShippingService, "OrderShipmentResponse"),
+    :schema_element => [
+      ["shipmentDateGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsShippingService, "ShipmentDateGMT")]],
+      ["carrierCode", ["SOAP::SOAPString", XSD::QName.new(NsShippingService, "CarrierCode")], [0, 1]],
+      ["classCode", ["SOAP::SOAPString", XSD::QName.new(NsShippingService, "ClassCode")], [0, 1]],
+      ["trackingNumber", ["SOAP::SOAPString", XSD::QName.new(NsShippingService, "TrackingNumber")], [0, 1]],
+      ["distributionCenterCode", ["SOAP::SOAPString", XSD::QName.new(NsShippingService, "DistributionCenterCode")], [0, 1]],
+      ["shipmentCost", ["SOAP::SOAPDecimal", XSD::QName.new(NsShippingService, "ShipmentCost")]],
+      ["shipmentTaxCost", ["SOAP::SOAPDecimal", XSD::QName.new(NsShippingService, "ShipmentTaxCost")]],
+      ["shipmentInsuranceCost", ["SOAP::SOAPDecimal", XSD::QName.new(NsShippingService, "ShipmentInsuranceCost")]],
+      ["sellerFulfillmentID", ["SOAP::SOAPString", XSD::QName.new(NsShippingService, "SellerFulfillmentID")], [0, 1]],
+      ["shipmentLineItems", ["ChannelAdvisor::ShippingServiceSOAP::ArrayOfShipmentLineItemResponse", XSD::QName.new(NsShippingService, "ShipmentLineItems")], [0, 1]],
+      ["fulfillmentType", ["SOAP::SOAPString", XSD::QName.new(NsShippingService, "FulfillmentType")], [0, 1]],
+      ["fulfillmentStatus", ["SOAP::SOAPString", XSD::QName.new(NsShippingService, "FulfillmentStatus")], [0, 1]]
+    ]
+  )
+
+  EncodedRegistry.register(
+    :class => ChannelAdvisor::ShippingServiceSOAP::ArrayOfShipmentLineItemResponse,
+    :schema_type => XSD::QName.new(NsShippingService, "ArrayOfShipmentLineItemResponse"),
+    :schema_element => [
+      ["shipmentLineItemResponse", ["ChannelAdvisor::ShippingServiceSOAP::ShipmentLineItemResponse[]", XSD::QName.new(NsShippingService, "ShipmentLineItemResponse")], [0, nil]]
+    ]
+  )
+
+  EncodedRegistry.register(
+    :class => ChannelAdvisor::ShippingServiceSOAP::ShipmentLineItemResponse,
+    :schema_type => XSD::QName.new(NsShippingService, "ShipmentLineItemResponse"),
+    :schema_element => [
+      ["lineItemID", ["SOAP::SOAPInt", XSD::QName.new(NsShippingService, "LineItemID")]],
+      ["sKU", ["SOAP::SOAPString", XSD::QName.new(NsShippingService, "SKU")], [0, 1]],
+      ["quantity", ["SOAP::SOAPInt", XSD::QName.new(NsShippingService, "Quantity")]]
+    ]
+  )
+
+  EncodedRegistry.register(
     :class => ChannelAdvisor::ShippingServiceSOAP::ShipmentResponse,
     :schema_type => XSD::QName.new(NsShippingService, "ShipmentResponse"),
     :schema_element => [
@@ -229,11 +280,6 @@ module DefaultMappingRegistry
   EncodedRegistry.register(
     :class => ChannelAdvisor::ShippingServiceSOAP::ResultStatus,
     :schema_type => XSD::QName.new(NsWebservices, "ResultStatus")
-  )
-
-  EncodedRegistry.register(
-    :class => ChannelAdvisor::ShippingServiceSOAP::ShipmentTypeEnum,
-    :schema_type => XSD::QName.new(NsWebservices, "ShipmentTypeEnum")
   )
 
   LiteralRegistry.register(
@@ -317,30 +363,38 @@ module DefaultMappingRegistry
   )
 
   LiteralRegistry.register(
-    :class => ChannelAdvisor::ShippingServiceSOAP::APIResultOfBoolean,
-    :schema_type => XSD::QName.new(NsWebservices, "APIResultOfBoolean"),
+    :class => ChannelAdvisor::ShippingServiceSOAP::ArrayOfInt,
+    :schema_type => XSD::QName.new(NsWebservices, "ArrayOfInt"),
+    :schema_element => [
+      ["int", "SOAP::SOAPInt[]", [0, nil]]
+    ]
+  )
+
+  LiteralRegistry.register(
+    :class => ChannelAdvisor::ShippingServiceSOAP::ArrayOfString,
+    :schema_type => XSD::QName.new(NsWebservices, "ArrayOfString"),
+    :schema_element => [
+      ["string", "SOAP::SOAPString[]", [0, nil]]
+    ]
+  )
+
+  LiteralRegistry.register(
+    :class => ChannelAdvisor::ShippingServiceSOAP::APIResultOfArrayOfOrderShipmentHistoryResponse,
+    :schema_type => XSD::QName.new(NsWebservices, "APIResultOfArrayOfOrderShipmentHistoryResponse"),
     :schema_element => [
       ["status", ["ChannelAdvisor::ShippingServiceSOAP::ResultStatus", XSD::QName.new(NsWebservices, "Status")]],
       ["messageCode", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "MessageCode")]],
       ["message", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Message")], [0, 1]],
       ["data", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "Data")], [0, 1]],
-      ["resultData", ["SOAP::SOAPBoolean", XSD::QName.new(NsWebservices, "ResultData")]]
+      ["resultData", ["ChannelAdvisor::ShippingServiceSOAP::ArrayOfOrderShipmentHistoryResponse", XSD::QName.new(NsWebservices, "ResultData")], [0, 1]]
     ]
   )
 
   LiteralRegistry.register(
-    :class => ChannelAdvisor::ShippingServiceSOAP::OrderShipmentList,
-    :schema_type => XSD::QName.new(NsWebservices, "OrderShipmentList"),
+    :class => ChannelAdvisor::ShippingServiceSOAP::ArrayOfOrderShipmentHistoryResponse,
+    :schema_type => XSD::QName.new(NsWebservices, "ArrayOfOrderShipmentHistoryResponse"),
     :schema_element => [
-      ["shipmentList", ["ChannelAdvisor::ShippingServiceSOAP::ArrayOfOrderShipment", XSD::QName.new(NsWebservices, "ShipmentList")], [0, 1]]
-    ]
-  )
-
-  LiteralRegistry.register(
-    :class => ChannelAdvisor::ShippingServiceSOAP::ArrayOfOrderShipment,
-    :schema_type => XSD::QName.new(NsWebservices, "ArrayOfOrderShipment"),
-    :schema_element => [
-      ["orderShipment", ["ChannelAdvisor::ShippingServiceSOAP::OrderShipment[]", XSD::QName.new(NsWebservices, "OrderShipment")], [0, nil]]
+      ["orderShipmentHistoryResponse", ["ChannelAdvisor::ShippingServiceSOAP::OrderShipmentHistoryResponse[]", XSD::QName.new(NsWebservices, "OrderShipmentHistoryResponse")], [0, nil]]
     ]
   )
 
@@ -348,9 +402,9 @@ module DefaultMappingRegistry
     :class => ChannelAdvisor::ShippingServiceSOAP::OrderShipment,
     :schema_type => XSD::QName.new(NsWebservices, "OrderShipment"),
     :schema_element => [
-      ["orderId", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "OrderId")]],
+      ["orderID", ["SOAP::SOAPInt", XSD::QName.new(NsWebservices, "OrderID")]],
       ["clientOrderIdentifier", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "ClientOrderIdentifier")], [0, 1]],
-      ["shipmentType", ["ChannelAdvisor::ShippingServiceSOAP::ShipmentTypeEnum", XSD::QName.new(NsWebservices, "ShipmentType")]],
+      ["shipmentType", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "ShipmentType")], [0, 1]],
       ["partialShipment", ["ChannelAdvisor::ShippingServiceSOAP::PartialShipmentContents", XSD::QName.new(NsWebservices, "PartialShipment")], [0, 1]],
       ["fullShipment", ["ChannelAdvisor::ShippingServiceSOAP::FullShipmentContents", XSD::QName.new(NsWebservices, "FullShipment")], [0, 1]]
     ]
@@ -360,31 +414,17 @@ module DefaultMappingRegistry
     :class => ChannelAdvisor::ShippingServiceSOAP::PartialShipmentContents,
     :schema_type => XSD::QName.new(NsWebservices, "PartialShipmentContents"),
     :schema_element => [
-      ["shipmentContents", "ChannelAdvisor::ShippingServiceSOAP::ShipmentContents"],
-      ["dateShippedGMT", "SOAP::SOAPDateTime"],
-      ["carrierCode", "SOAP::SOAPString", [0, 1]],
-      ["classCode", "SOAP::SOAPString", [0, 1]],
-      ["trackingNumber", "SOAP::SOAPString", [0, 1]],
-      ["sellerFulfillmentID", "SOAP::SOAPString", [0, 1]],
-      ["shipmentCost", "SOAP::SOAPDecimal"],
-      ["shipmentTaxCost", "SOAP::SOAPDecimal"],
-      ["insuranceCost", "SOAP::SOAPDecimal"]
-    ]
-  )
-
-  LiteralRegistry.register(
-    :class => ChannelAdvisor::ShippingServiceSOAP::ShipmentContents,
-    :schema_type => XSD::QName.new(NsWebservices, "ShipmentContents"),
-    :schema_element => [
-      ["lineItemList", ["ChannelAdvisor::ShippingServiceSOAP::ArrayOfLineItem", XSD::QName.new(NsWebservices, "LineItemList")], [0, 1]]
-    ]
-  )
-
-  LiteralRegistry.register(
-    :class => ChannelAdvisor::ShippingServiceSOAP::ArrayOfLineItem,
-    :schema_type => XSD::QName.new(NsWebservices, "ArrayOfLineItem"),
-    :schema_element => [
-      ["lineItem", ["ChannelAdvisor::ShippingServiceSOAP::LineItem[]", XSD::QName.new(NsWebservices, "LineItem")], [0, nil]]
+      ["lineItemList", ["ChannelAdvisor::ShippingServiceSOAP::LineItem[]", XSD::QName.new(NsWebservices, "LineItemList")], [0, nil]],
+      ["dateShippedGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsWebservices, "DateShippedGMT")]],
+      ["carrierCode", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "CarrierCode")], [0, 1]],
+      ["classCode", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "ClassCode")], [0, 1]],
+      ["trackingNumber", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "TrackingNumber")], [0, 1]],
+      ["sellerFulfillmentID", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "SellerFulfillmentID")], [0, 1]],
+      ["shipmentCost", ["SOAP::SOAPDecimal", XSD::QName.new(NsWebservices, "ShipmentCost")]],
+      ["shipmentTaxCost", ["SOAP::SOAPDecimal", XSD::QName.new(NsWebservices, "ShipmentTaxCost")]],
+      ["insuranceCost", ["SOAP::SOAPDecimal", XSD::QName.new(NsWebservices, "InsuranceCost")]],
+      ["fulfillmentType", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "FulfillmentType")], [0, 1]],
+      ["fulfillmentStatus", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "FulfillmentStatus")], [0, 1]]
     ]
   )
 
@@ -401,14 +441,14 @@ module DefaultMappingRegistry
     :class => ChannelAdvisor::ShippingServiceSOAP::FullShipmentContents,
     :schema_type => XSD::QName.new(NsWebservices, "FullShipmentContents"),
     :schema_element => [
-      ["dateShippedGMT", "SOAP::SOAPDateTime"],
-      ["carrierCode", "SOAP::SOAPString", [0, 1]],
-      ["classCode", "SOAP::SOAPString", [0, 1]],
-      ["trackingNumber", "SOAP::SOAPString", [0, 1]],
-      ["sellerFulfillmentID", "SOAP::SOAPString", [0, 1]],
-      ["shipmentCost", "SOAP::SOAPDecimal"],
-      ["shipmentTaxCost", "SOAP::SOAPDecimal"],
-      ["insuranceCost", "SOAP::SOAPDecimal"]
+      ["dateShippedGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsWebservices, "DateShippedGMT")]],
+      ["carrierCode", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "CarrierCode")], [0, 1]],
+      ["classCode", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "ClassCode")], [0, 1]],
+      ["trackingNumber", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "TrackingNumber")], [0, 1]],
+      ["sellerFulfillmentID", ["SOAP::SOAPString", XSD::QName.new(NsWebservices, "SellerFulfillmentID")], [0, 1]],
+      ["shipmentCost", ["SOAP::SOAPDecimal", XSD::QName.new(NsWebservices, "ShipmentCost")]],
+      ["shipmentTaxCost", ["SOAP::SOAPDecimal", XSD::QName.new(NsWebservices, "ShipmentTaxCost")]],
+      ["insuranceCost", ["SOAP::SOAPDecimal", XSD::QName.new(NsWebservices, "InsuranceCost")]]
     ]
   )
 
@@ -445,6 +485,63 @@ module DefaultMappingRegistry
   )
 
   LiteralRegistry.register(
+    :class => ChannelAdvisor::ShippingServiceSOAP::OrderShipmentHistoryResponse,
+    :schema_type => XSD::QName.new(NsShippingService, "OrderShipmentHistoryResponse"),
+    :schema_element => [
+      ["orderID", ["SOAP::SOAPInt", XSD::QName.new(NsShippingService, "OrderID")]],
+      ["clientOrderIdentifier", ["SOAP::SOAPString", XSD::QName.new(NsShippingService, "ClientOrderIdentifier")], [0, 1]],
+      ["shippingStatus", ["SOAP::SOAPString", XSD::QName.new(NsShippingService, "ShippingStatus")], [0, 1]],
+      ["shippingStatusUpdateDateGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsShippingService, "ShippingStatusUpdateDateGMT")]],
+      ["orderShipments", ["ChannelAdvisor::ShippingServiceSOAP::ArrayOfOrderShipmentResponse", XSD::QName.new(NsShippingService, "OrderShipments")], [0, 1]]
+    ]
+  )
+
+  LiteralRegistry.register(
+    :class => ChannelAdvisor::ShippingServiceSOAP::ArrayOfOrderShipmentResponse,
+    :schema_type => XSD::QName.new(NsShippingService, "ArrayOfOrderShipmentResponse"),
+    :schema_element => [
+      ["orderShipmentResponse", ["ChannelAdvisor::ShippingServiceSOAP::OrderShipmentResponse[]", XSD::QName.new(NsShippingService, "OrderShipmentResponse")], [0, nil]]
+    ]
+  )
+
+  LiteralRegistry.register(
+    :class => ChannelAdvisor::ShippingServiceSOAP::OrderShipmentResponse,
+    :schema_type => XSD::QName.new(NsShippingService, "OrderShipmentResponse"),
+    :schema_element => [
+      ["shipmentDateGMT", ["SOAP::SOAPDateTime", XSD::QName.new(NsShippingService, "ShipmentDateGMT")]],
+      ["carrierCode", ["SOAP::SOAPString", XSD::QName.new(NsShippingService, "CarrierCode")], [0, 1]],
+      ["classCode", ["SOAP::SOAPString", XSD::QName.new(NsShippingService, "ClassCode")], [0, 1]],
+      ["trackingNumber", ["SOAP::SOAPString", XSD::QName.new(NsShippingService, "TrackingNumber")], [0, 1]],
+      ["distributionCenterCode", ["SOAP::SOAPString", XSD::QName.new(NsShippingService, "DistributionCenterCode")], [0, 1]],
+      ["shipmentCost", ["SOAP::SOAPDecimal", XSD::QName.new(NsShippingService, "ShipmentCost")]],
+      ["shipmentTaxCost", ["SOAP::SOAPDecimal", XSD::QName.new(NsShippingService, "ShipmentTaxCost")]],
+      ["shipmentInsuranceCost", ["SOAP::SOAPDecimal", XSD::QName.new(NsShippingService, "ShipmentInsuranceCost")]],
+      ["sellerFulfillmentID", ["SOAP::SOAPString", XSD::QName.new(NsShippingService, "SellerFulfillmentID")], [0, 1]],
+      ["shipmentLineItems", ["ChannelAdvisor::ShippingServiceSOAP::ArrayOfShipmentLineItemResponse", XSD::QName.new(NsShippingService, "ShipmentLineItems")], [0, 1]],
+      ["fulfillmentType", ["SOAP::SOAPString", XSD::QName.new(NsShippingService, "FulfillmentType")], [0, 1]],
+      ["fulfillmentStatus", ["SOAP::SOAPString", XSD::QName.new(NsShippingService, "FulfillmentStatus")], [0, 1]]
+    ]
+  )
+
+  LiteralRegistry.register(
+    :class => ChannelAdvisor::ShippingServiceSOAP::ArrayOfShipmentLineItemResponse,
+    :schema_type => XSD::QName.new(NsShippingService, "ArrayOfShipmentLineItemResponse"),
+    :schema_element => [
+      ["shipmentLineItemResponse", ["ChannelAdvisor::ShippingServiceSOAP::ShipmentLineItemResponse[]", XSD::QName.new(NsShippingService, "ShipmentLineItemResponse")], [0, nil]]
+    ]
+  )
+
+  LiteralRegistry.register(
+    :class => ChannelAdvisor::ShippingServiceSOAP::ShipmentLineItemResponse,
+    :schema_type => XSD::QName.new(NsShippingService, "ShipmentLineItemResponse"),
+    :schema_element => [
+      ["lineItemID", ["SOAP::SOAPInt", XSD::QName.new(NsShippingService, "LineItemID")]],
+      ["sKU", ["SOAP::SOAPString", XSD::QName.new(NsShippingService, "SKU")], [0, 1]],
+      ["quantity", ["SOAP::SOAPInt", XSD::QName.new(NsShippingService, "Quantity")]]
+    ]
+  )
+
+  LiteralRegistry.register(
     :class => ChannelAdvisor::ShippingServiceSOAP::ShipmentResponse,
     :schema_type => XSD::QName.new(NsShippingService, "ShipmentResponse"),
     :schema_element => [
@@ -456,11 +553,6 @@ module DefaultMappingRegistry
   LiteralRegistry.register(
     :class => ChannelAdvisor::ShippingServiceSOAP::ResultStatus,
     :schema_type => XSD::QName.new(NsWebservices, "ResultStatus")
-  )
-
-  LiteralRegistry.register(
-    :class => ChannelAdvisor::ShippingServiceSOAP::ShipmentTypeEnum,
-    :schema_type => XSD::QName.new(NsWebservices, "ShipmentTypeEnum")
   )
 
   LiteralRegistry.register(
@@ -498,7 +590,7 @@ module DefaultMappingRegistry
     :class => ChannelAdvisor::ShippingServiceSOAP::GetShippingCarrierList,
     :schema_name => XSD::QName.new(NsWebservices, "GetShippingCarrierList"),
     :schema_element => [
-      ["accountID", "SOAP::SOAPString", [0, 1]]
+      ["accountID", "SOAP::SOAPString"]
     ]
   )
 
@@ -511,24 +603,20 @@ module DefaultMappingRegistry
   )
 
   LiteralRegistry.register(
-    :class => ChannelAdvisor::ShippingServiceSOAP::OrderShipped,
-    :schema_name => XSD::QName.new(NsWebservices, "OrderShipped"),
+    :class => ChannelAdvisor::ShippingServiceSOAP::GetOrderShipmentHistoryList,
+    :schema_name => XSD::QName.new(NsWebservices, "GetOrderShipmentHistoryList"),
     :schema_element => [
-      ["accountID", "SOAP::SOAPString", [0, 1]],
-      ["orderID", "SOAP::SOAPInt"],
-      ["dateShippedGMT", "SOAP::SOAPDateTime"],
-      ["carrierCode", "SOAP::SOAPString", [0, 1]],
-      ["classCode", "SOAP::SOAPString", [0, 1]],
-      ["trackingNumber", "SOAP::SOAPString", [0, 1]],
-      ["sellerFulfillmentID", "SOAP::SOAPString", [0, 1]]
+      ["accountID", "SOAP::SOAPString"],
+      ["orderIDList", "ChannelAdvisor::ShippingServiceSOAP::ArrayOfInt", [0, 1]],
+      ["clientOrderIdentifierList", "ChannelAdvisor::ShippingServiceSOAP::ArrayOfString", [0, 1]]
     ]
   )
 
   LiteralRegistry.register(
-    :class => ChannelAdvisor::ShippingServiceSOAP::OrderShippedResponse,
-    :schema_name => XSD::QName.new(NsWebservices, "OrderShippedResponse"),
+    :class => ChannelAdvisor::ShippingServiceSOAP::GetOrderShipmentHistoryListResponse,
+    :schema_name => XSD::QName.new(NsWebservices, "GetOrderShipmentHistoryListResponse"),
     :schema_element => [
-      ["orderShippedResult", ["ChannelAdvisor::ShippingServiceSOAP::APIResultOfBoolean", XSD::QName.new(NsWebservices, "OrderShippedResult")], [0, 1]]
+      ["getOrderShipmentHistoryListResult", ["ChannelAdvisor::ShippingServiceSOAP::APIResultOfArrayOfOrderShipmentHistoryResponse", XSD::QName.new(NsWebservices, "GetOrderShipmentHistoryListResult")], [0, 1]]
     ]
   )
 
@@ -536,8 +624,8 @@ module DefaultMappingRegistry
     :class => ChannelAdvisor::ShippingServiceSOAP::SubmitOrderShipmentList,
     :schema_name => XSD::QName.new(NsWebservices, "SubmitOrderShipmentList"),
     :schema_element => [
-      ["accountID", "SOAP::SOAPString", [0, 1]],
-      ["shipmentList", ["ChannelAdvisor::ShippingServiceSOAP::OrderShipmentList", XSD::QName.new(NsWebservices, "ShipmentList")], [0, 1]]
+      ["accountID", "SOAP::SOAPString"],
+      ["shipmentList", "ChannelAdvisor::ShippingServiceSOAP::OrderShipment[]", [0, nil]]
     ]
   )
 

--- a/lib/channel_advisor/shipping_service/types.rb
+++ b/lib/channel_advisor/shipping_service/types.rb
@@ -119,13 +119,21 @@ class ShippingCarrier
   end
 end
 
-# {http://api.channeladvisor.com/webservices/}APIResultOfBoolean
+# {http://api.channeladvisor.com/webservices/}ArrayOfInt
+class ArrayOfInt < ::Array
+end
+
+# {http://api.channeladvisor.com/webservices/}ArrayOfString
+class ArrayOfString < ::Array
+end
+
+# {http://api.channeladvisor.com/webservices/}APIResultOfArrayOfOrderShipmentHistoryResponse
 #   status - ChannelAdvisor::ShippingServiceSOAP::ResultStatus
 #   messageCode - SOAP::SOAPInt
 #   message - SOAP::SOAPString
 #   data - SOAP::SOAPString
-#   resultData - SOAP::SOAPBoolean
-class APIResultOfBoolean
+#   resultData - ChannelAdvisor::ShippingServiceSOAP::ArrayOfOrderShipmentHistoryResponse
+class APIResultOfArrayOfOrderShipmentHistoryResponse
   attr_accessor :status
   attr_accessor :messageCode
   attr_accessor :message
@@ -141,35 +149,25 @@ class APIResultOfBoolean
   end
 end
 
-# {http://api.channeladvisor.com/webservices/}OrderShipmentList
-#   shipmentList - ChannelAdvisor::ShippingServiceSOAP::ArrayOfOrderShipment
-class OrderShipmentList
-  attr_accessor :shipmentList
-
-  def initialize(shipmentList = nil)
-    @shipmentList = shipmentList
-  end
-end
-
-# {http://api.channeladvisor.com/webservices/}ArrayOfOrderShipment
-class ArrayOfOrderShipment < ::Array
+# {http://api.channeladvisor.com/webservices/}ArrayOfOrderShipmentHistoryResponse
+class ArrayOfOrderShipmentHistoryResponse < ::Array
 end
 
 # {http://api.channeladvisor.com/webservices/}OrderShipment
-#   orderId - SOAP::SOAPInt
+#   orderID - SOAP::SOAPInt
 #   clientOrderIdentifier - SOAP::SOAPString
-#   shipmentType - ChannelAdvisor::ShippingServiceSOAP::ShipmentTypeEnum
+#   shipmentType - SOAP::SOAPString
 #   partialShipment - ChannelAdvisor::ShippingServiceSOAP::PartialShipmentContents
 #   fullShipment - ChannelAdvisor::ShippingServiceSOAP::FullShipmentContents
 class OrderShipment
-  attr_accessor :orderId
+  attr_accessor :orderID
   attr_accessor :clientOrderIdentifier
   attr_accessor :shipmentType
   attr_accessor :partialShipment
   attr_accessor :fullShipment
 
-  def initialize(orderId = nil, clientOrderIdentifier = nil, shipmentType = nil, partialShipment = nil, fullShipment = nil)
-    @orderId = orderId
+  def initialize(orderID = nil, clientOrderIdentifier = nil, shipmentType = nil, partialShipment = nil, fullShipment = nil)
+    @orderID = orderID
     @clientOrderIdentifier = clientOrderIdentifier
     @shipmentType = shipmentType
     @partialShipment = partialShipment
@@ -178,7 +176,7 @@ class OrderShipment
 end
 
 # {http://api.channeladvisor.com/webservices/}PartialShipmentContents
-#   shipmentContents - ChannelAdvisor::ShippingServiceSOAP::ShipmentContents
+#   lineItemList - ChannelAdvisor::ShippingServiceSOAP::LineItem
 #   dateShippedGMT - SOAP::SOAPDateTime
 #   carrierCode - SOAP::SOAPString
 #   classCode - SOAP::SOAPString
@@ -187,8 +185,10 @@ end
 #   shipmentCost - SOAP::SOAPDecimal
 #   shipmentTaxCost - SOAP::SOAPDecimal
 #   insuranceCost - SOAP::SOAPDecimal
+#   fulfillmentType - SOAP::SOAPString
+#   fulfillmentStatus - SOAP::SOAPString
 class PartialShipmentContents
-  attr_accessor :shipmentContents
+  attr_accessor :lineItemList
   attr_accessor :dateShippedGMT
   attr_accessor :carrierCode
   attr_accessor :classCode
@@ -197,9 +197,11 @@ class PartialShipmentContents
   attr_accessor :shipmentCost
   attr_accessor :shipmentTaxCost
   attr_accessor :insuranceCost
+  attr_accessor :fulfillmentType
+  attr_accessor :fulfillmentStatus
 
-  def initialize(shipmentContents = nil, dateShippedGMT = nil, carrierCode = nil, classCode = nil, trackingNumber = nil, sellerFulfillmentID = nil, shipmentCost = nil, shipmentTaxCost = nil, insuranceCost = nil)
-    @shipmentContents = shipmentContents
+  def initialize(lineItemList = [], dateShippedGMT = nil, carrierCode = nil, classCode = nil, trackingNumber = nil, sellerFulfillmentID = nil, shipmentCost = nil, shipmentTaxCost = nil, insuranceCost = nil, fulfillmentType = nil, fulfillmentStatus = nil)
+    @lineItemList = lineItemList
     @dateShippedGMT = dateShippedGMT
     @carrierCode = carrierCode
     @classCode = classCode
@@ -208,21 +210,9 @@ class PartialShipmentContents
     @shipmentCost = shipmentCost
     @shipmentTaxCost = shipmentTaxCost
     @insuranceCost = insuranceCost
+    @fulfillmentType = fulfillmentType
+    @fulfillmentStatus = fulfillmentStatus
   end
-end
-
-# {http://api.channeladvisor.com/webservices/}ShipmentContents
-#   lineItemList - ChannelAdvisor::ShippingServiceSOAP::ArrayOfLineItem
-class ShipmentContents
-  attr_accessor :lineItemList
-
-  def initialize(lineItemList = nil)
-    @lineItemList = lineItemList
-  end
-end
-
-# {http://api.channeladvisor.com/webservices/}ArrayOfLineItem
-class ArrayOfLineItem < ::Array
 end
 
 # {http://api.channeladvisor.com/webservices/}LineItem
@@ -317,6 +307,95 @@ class APIResultOfString
   end
 end
 
+# {http://api.channeladvisor.com/datacontracts/ShippingService}OrderShipmentHistoryResponse
+#   orderID - SOAP::SOAPInt
+#   clientOrderIdentifier - SOAP::SOAPString
+#   shippingStatus - SOAP::SOAPString
+#   shippingStatusUpdateDateGMT - SOAP::SOAPDateTime
+#   orderShipments - ChannelAdvisor::ShippingServiceSOAP::ArrayOfOrderShipmentResponse
+class OrderShipmentHistoryResponse
+  attr_accessor :orderID
+  attr_accessor :clientOrderIdentifier
+  attr_accessor :shippingStatus
+  attr_accessor :shippingStatusUpdateDateGMT
+  attr_accessor :orderShipments
+
+  def initialize(orderID = nil, clientOrderIdentifier = nil, shippingStatus = nil, shippingStatusUpdateDateGMT = nil, orderShipments = nil)
+    @orderID = orderID
+    @clientOrderIdentifier = clientOrderIdentifier
+    @shippingStatus = shippingStatus
+    @shippingStatusUpdateDateGMT = shippingStatusUpdateDateGMT
+    @orderShipments = orderShipments
+  end
+end
+
+# {http://api.channeladvisor.com/datacontracts/ShippingService}ArrayOfOrderShipmentResponse
+class ArrayOfOrderShipmentResponse < ::Array
+end
+
+# {http://api.channeladvisor.com/datacontracts/ShippingService}OrderShipmentResponse
+#   shipmentDateGMT - SOAP::SOAPDateTime
+#   carrierCode - SOAP::SOAPString
+#   classCode - SOAP::SOAPString
+#   trackingNumber - SOAP::SOAPString
+#   distributionCenterCode - SOAP::SOAPString
+#   shipmentCost - SOAP::SOAPDecimal
+#   shipmentTaxCost - SOAP::SOAPDecimal
+#   shipmentInsuranceCost - SOAP::SOAPDecimal
+#   sellerFulfillmentID - SOAP::SOAPString
+#   shipmentLineItems - ChannelAdvisor::ShippingServiceSOAP::ArrayOfShipmentLineItemResponse
+#   fulfillmentType - SOAP::SOAPString
+#   fulfillmentStatus - SOAP::SOAPString
+class OrderShipmentResponse
+  attr_accessor :shipmentDateGMT
+  attr_accessor :carrierCode
+  attr_accessor :classCode
+  attr_accessor :trackingNumber
+  attr_accessor :distributionCenterCode
+  attr_accessor :shipmentCost
+  attr_accessor :shipmentTaxCost
+  attr_accessor :shipmentInsuranceCost
+  attr_accessor :sellerFulfillmentID
+  attr_accessor :shipmentLineItems
+  attr_accessor :fulfillmentType
+  attr_accessor :fulfillmentStatus
+
+  def initialize(shipmentDateGMT = nil, carrierCode = nil, classCode = nil, trackingNumber = nil, distributionCenterCode = nil, shipmentCost = nil, shipmentTaxCost = nil, shipmentInsuranceCost = nil, sellerFulfillmentID = nil, shipmentLineItems = nil, fulfillmentType = nil, fulfillmentStatus = nil)
+    @shipmentDateGMT = shipmentDateGMT
+    @carrierCode = carrierCode
+    @classCode = classCode
+    @trackingNumber = trackingNumber
+    @distributionCenterCode = distributionCenterCode
+    @shipmentCost = shipmentCost
+    @shipmentTaxCost = shipmentTaxCost
+    @shipmentInsuranceCost = shipmentInsuranceCost
+    @sellerFulfillmentID = sellerFulfillmentID
+    @shipmentLineItems = shipmentLineItems
+    @fulfillmentType = fulfillmentType
+    @fulfillmentStatus = fulfillmentStatus
+  end
+end
+
+# {http://api.channeladvisor.com/datacontracts/ShippingService}ArrayOfShipmentLineItemResponse
+class ArrayOfShipmentLineItemResponse < ::Array
+end
+
+# {http://api.channeladvisor.com/datacontracts/ShippingService}ShipmentLineItemResponse
+#   lineItemID - SOAP::SOAPInt
+#   sKU - SOAP::SOAPString
+#   quantity - SOAP::SOAPInt
+class ShipmentLineItemResponse
+  attr_accessor :lineItemID
+  attr_accessor :sKU
+  attr_accessor :quantity
+
+  def initialize(lineItemID = nil, sKU = nil, quantity = nil)
+    @lineItemID = lineItemID
+    @sKU = sKU
+    @quantity = quantity
+  end
+end
+
 # {http://api.channeladvisor.com/datacontracts/ShippingService}ShipmentResponse
 #   success - SOAP::SOAPBoolean
 #   message - SOAP::SOAPString
@@ -334,12 +413,6 @@ end
 class ResultStatus < ::String
   Failure = new("Failure")
   Success = new("Success")
-end
-
-# {http://api.channeladvisor.com/webservices/}ShipmentTypeEnum
-class ShipmentTypeEnum < ::String
-  Full = new("Full")
-  Partial = new("Partial")
 end
 
 # {http://api.channeladvisor.com/webservices/}GetShippingRateList
@@ -400,52 +473,40 @@ class GetShippingCarrierListResponse
   end
 end
 
-# {http://api.channeladvisor.com/webservices/}OrderShipped
+# {http://api.channeladvisor.com/webservices/}GetOrderShipmentHistoryList
 #   accountID - SOAP::SOAPString
-#   orderID - SOAP::SOAPInt
-#   dateShippedGMT - SOAP::SOAPDateTime
-#   carrierCode - SOAP::SOAPString
-#   classCode - SOAP::SOAPString
-#   trackingNumber - SOAP::SOAPString
-#   sellerFulfillmentID - SOAP::SOAPString
-class OrderShipped
+#   orderIDList - ChannelAdvisor::ShippingServiceSOAP::ArrayOfInt
+#   clientOrderIdentifierList - ChannelAdvisor::ShippingServiceSOAP::ArrayOfString
+class GetOrderShipmentHistoryList
   attr_accessor :accountID
-  attr_accessor :orderID
-  attr_accessor :dateShippedGMT
-  attr_accessor :carrierCode
-  attr_accessor :classCode
-  attr_accessor :trackingNumber
-  attr_accessor :sellerFulfillmentID
+  attr_accessor :orderIDList
+  attr_accessor :clientOrderIdentifierList
 
-  def initialize(accountID = nil, orderID = nil, dateShippedGMT = nil, carrierCode = nil, classCode = nil, trackingNumber = nil, sellerFulfillmentID = nil)
+  def initialize(accountID = nil, orderIDList = nil, clientOrderIdentifierList = nil)
     @accountID = accountID
-    @orderID = orderID
-    @dateShippedGMT = dateShippedGMT
-    @carrierCode = carrierCode
-    @classCode = classCode
-    @trackingNumber = trackingNumber
-    @sellerFulfillmentID = sellerFulfillmentID
+    @orderIDList = orderIDList
+    @clientOrderIdentifierList = clientOrderIdentifierList
   end
 end
 
-# {http://api.channeladvisor.com/webservices/}OrderShippedResponse
-#   orderShippedResult - ChannelAdvisor::ShippingServiceSOAP::APIResultOfBoolean
-class OrderShippedResponse
-  attr_accessor :orderShippedResult
+# {http://api.channeladvisor.com/webservices/}GetOrderShipmentHistoryListResponse
+#   getOrderShipmentHistoryListResult - ChannelAdvisor::ShippingServiceSOAP::APIResultOfArrayOfOrderShipmentHistoryResponse
+class GetOrderShipmentHistoryListResponse
+  attr_accessor :getOrderShipmentHistoryListResult
 
-  def initialize(orderShippedResult = nil)
-    @orderShippedResult = orderShippedResult
+  def initialize(getOrderShipmentHistoryListResult = nil)
+    @getOrderShipmentHistoryListResult = getOrderShipmentHistoryListResult
   end
 end
 
 # {http://api.channeladvisor.com/webservices/}SubmitOrderShipmentList
 #   accountID - SOAP::SOAPString
-#   shipmentList - ChannelAdvisor::ShippingServiceSOAP::OrderShipmentList
+#   shipmentList - ChannelAdvisor::ShippingServiceSOAP::OrderShipment
 class SubmitOrderShipmentList
   attr_accessor :accountID
   attr_accessor :shipmentList
 
-  def initialize(accountID = nil, shipmentList = nil)
+  def initialize(accountID = nil, shipmentList = [])
     @accountID = accountID
     @shipmentList = shipmentList
   end

--- a/lib/channel_advisor/store_service/client.rb
+++ b/lib/channel_advisor/store_service/client.rb
@@ -6,7 +6,7 @@ module ChannelAdvisor
 module StoreServiceSOAP
 
 class StoreServiceSoap < ::SOAP::RPC::Driver
-  DefaultEndpointUrl = "https://api.channeladvisor.com/ChannelAdvisorAPI/v4/StoreService.asmx"
+  DefaultEndpointUrl = "https://api.channeladvisor.com/ChannelAdvisorAPI/v7/StoreService.asmx"
 
   Methods = [
     [ "http://api.channeladvisor.com/webservices/GetSearchAnalysisStats",

--- a/lib/channel_advisor/tax_service/client.rb
+++ b/lib/channel_advisor/tax_service/client.rb
@@ -6,7 +6,7 @@ module ChannelAdvisor
 module TaxServiceSOAP
 
 class TaxServiceSoap < ::SOAP::RPC::Driver
-  DefaultEndpointUrl = "https://api.channeladvisor.com/ChannelAdvisorAPI/v4/TaxService.asmx"
+  DefaultEndpointUrl = "https://api.channeladvisor.com/ChannelAdvisorAPI/v7/TaxService.asmx"
 
   Methods = [
     [ "http://api.channeladvisor.com/webservices/GetTaxRateList",


### PR DESCRIPTION
@blatyo -- this version is working for my CA scripts (which uses CA OrderService in various ways). Maybe it'll just work with all of our stuff (in the documentation, CA specifically says that all WADLs stay the same). I'm not sure why we couldn't upgrade earlier on - maybe because of older ruby version.

I bumped major version, so we wouldn't upgrade CA version on accident. (Or I guess I can update just minor version..)